### PR TITLE
AUTH manager refactoring

### DIFF
--- a/client/src/main/com/sinch/sdk/SinchClient.java
+++ b/client/src/main/com/sinch/sdk/SinchClient.java
@@ -36,6 +36,12 @@ public class SinchClient {
 
   private HttpClientApache httpClient;
 
+  // TODO: generator tools do not generate security schemas related information.
+  // Will have to fix it with a generic way
+  public static final String SECURITY_SCHEME_KEYWORD_NUMBERS = "BasicAuth";
+  public static final String SECURITY_SCHEME_KEYWORD_VERIFICATION = "Basic";
+  public static final String SECURITY_SCHEME_KEYWORD_SMS = "BearerAuth";
+
   /**
    * Create a Sinch Client instance based onto configuration
    *
@@ -147,8 +153,11 @@ public class SinchClient {
       BearerAuthManager bearerAuthManager = new BearerAuthManager(configuration, new HttpMapper());
 
       Map<String, AuthManager> authManagers =
-          Stream.of(basicAuthManager, bearerAuthManager)
-              .map(e -> new AbstractMap.SimpleEntry<>(e.getSchema(), e))
+          Stream.of(
+                  new AbstractMap.SimpleEntry<>(SECURITY_SCHEME_KEYWORD_NUMBERS, basicAuthManager),
+                  new AbstractMap.SimpleEntry<>(
+                      SECURITY_SCHEME_KEYWORD_VERIFICATION, basicAuthManager),
+                  new AbstractMap.SimpleEntry<>(SECURITY_SCHEME_KEYWORD_SMS, bearerAuthManager))
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
       // TODO: by adding a setter, we could imagine having another HTTP client provided

--- a/client/src/main/com/sinch/sdk/auth/adapters/BasicAuthManager.java
+++ b/client/src/main/com/sinch/sdk/auth/adapters/BasicAuthManager.java
@@ -7,8 +7,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 public class BasicAuthManager implements AuthManager {
-  public static final String BASIC_SCHEMA_KEYWORD = "BasicAuth";
-  private static final String BASIC_AUTH_KEYWORD = "Basic";
+  private static final String SCHEMA_KEYWORD = "Basic";
+  private static final String AUTH_KEYWORD = "Basic";
   private final Configuration configuration;
 
   public BasicAuthManager(Configuration configuration) {
@@ -16,7 +16,7 @@ public class BasicAuthManager implements AuthManager {
   }
 
   public String getSchema() {
-    return BASIC_SCHEMA_KEYWORD;
+    return SCHEMA_KEYWORD;
   }
 
   @Override
@@ -36,7 +36,7 @@ public class BasicAuthManager implements AuthManager {
 
     String raw = key + ":" + secret;
 
-    return BASIC_AUTH_KEYWORD
+    return AUTH_KEYWORD
         + " "
         + Base64.getEncoder().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
   }

--- a/client/src/main/com/sinch/sdk/auth/adapters/BearerAuthManager.java
+++ b/client/src/main/com/sinch/sdk/auth/adapters/BearerAuthManager.java
@@ -15,11 +15,11 @@ import java.util.Optional;
 import java.util.logging.Logger;
 
 public class BearerAuthManager implements AuthManager {
-  public static final String BEARER_SCHEMA_KEYWORD = "BearerAuth";
   public static final String BEARER_EXPIRED_KEYWORD = "expired";
   public static final String BEARER_AUTHENTICATE_RESPONSE_HEADER_KEYWORD = "www-authenticate";
   private static final Logger LOGGER = Logger.getLogger(BearerAuthManager.class.getName());
-  private static final String BEARER_AUTH_KEYWORD = "Bearer";
+  private static final String SCHEMA_KEYWORD = "Bearer";
+  private static final String AUTH_KEYWORD = "Bearer";
   private static final int maxRefreshAttempt = 5;
   private final Configuration configuration;
   private final HttpMapper mapper;
@@ -32,7 +32,7 @@ public class BearerAuthManager implements AuthManager {
   }
 
   public String getSchema() {
-    return BEARER_SCHEMA_KEYWORD;
+    return SCHEMA_KEYWORD;
   }
 
   @Override
@@ -51,7 +51,7 @@ public class BearerAuthManager implements AuthManager {
     if (token == null) {
       refreshToken();
     }
-    return BEARER_AUTH_KEYWORD + " " + token;
+    return AUTH_KEYWORD + " " + token;
   }
 
   private void refreshToken() {
@@ -80,7 +80,7 @@ public class BearerAuthManager implements AuthManager {
             null,
             null,
             Collections.singletonList("application/x-www-form-urlencoded"),
-            Collections.singletonList(BasicAuthManager.BASIC_SCHEMA_KEYWORD));
+            Collections.singletonList("Basic"));
     try {
       HttpResponse httpResponse = httpClient.invokeAPI(configuration.getOAuthServer(), request);
       BearerAuthResponse authResponse =

--- a/client/src/main/com/sinch/sdk/domains/numbers/NumbersService.java
+++ b/client/src/main/com/sinch/sdk/domains/numbers/NumbersService.java
@@ -34,7 +34,7 @@ public interface NumbersService {
   ActiveNumberService active();
 
   /**
-   * Callbacks Configuraiton Service instance
+   * Callbacks Configuration Service instance
    *
    * @return service instance for project
    * @since 1.0

--- a/client/src/main/com/sinch/sdk/domains/sms/GroupsService.java
+++ b/client/src/main/com/sinch/sdk/domains/sms/GroupsService.java
@@ -114,6 +114,7 @@ public interface GroupsService {
    * Get phone numbers for a group
    *
    * @param groupId ID of a group that you are interested in getting.
+   * @return A list of phone numbers in E.164 format.
    * @see <a
    *     href="https://developers.sinch.com/docs/sms/api-reference/sms/tag/Groups/#tag/Groups/operation/deleteGroup">https://developers.sinch.com/docs/sms/api-reference/sms/tag/Groups/#tag/Groups/operation/deleteGroup</a>
    * @since 1.0

--- a/client/src/test/java/com/sinch/sdk/auth/adapters/BasicAuthManagerTest.java
+++ b/client/src/test/java/com/sinch/sdk/auth/adapters/BasicAuthManagerTest.java
@@ -21,7 +21,7 @@ class BasicAuthManagerTest {
 
   @Test
   void getSchema() {
-    assertEquals("BasicAuth", authManager.getSchema());
+    assertEquals("Basic", authManager.getSchema());
   }
 
   @Test

--- a/client/src/test/java/com/sinch/sdk/auth/adapters/BearerAuthManagerTest.java
+++ b/client/src/test/java/com/sinch/sdk/auth/adapters/BearerAuthManagerTest.java
@@ -46,7 +46,7 @@ public class BearerAuthManagerTest extends BaseTest {
 
   @Test
   void getSchema() {
-    assertEquals("BearerAuth", authManager.getSchema());
+    assertEquals("Bearer", authManager.getSchema());
   }
 
   @Test
@@ -79,7 +79,7 @@ public class BearerAuthManagerTest extends BaseTest {
 
     HttpRequest httpRequestCaptorValue = httpRequestCaptor.getValue();
     assertEquals(HttpMethod.POST, httpRequestCaptorValue.getMethod());
-    assertTrue(httpRequestCaptorValue.getAuthNames().stream().anyMatch(e -> e.equals("BasicAuth")));
+    assertTrue(httpRequestCaptorValue.getAuthNames().stream().anyMatch(e -> e.equals("Basic")));
     assertTrue(
         httpRequestCaptorValue.getContentType().stream()
             .anyMatch(e -> e.equals("application/x-www-form-urlencoded")));

--- a/client/src/test/java/com/sinch/sdk/core/adapters/apache/HttpClientTestIT.java
+++ b/client/src/test/java/com/sinch/sdk/core/adapters/apache/HttpClientTestIT.java
@@ -83,7 +83,7 @@ class HttpClientTestIT extends BaseTest {
             null,
             null,
             null,
-            Collections.singletonList(BasicAuthManager.BASIC_SCHEMA_KEYWORD)));
+            Collections.singletonList(basicAuthManager.getSchema())));
     RecordedRequest recordedRequest = mockBackEnd.takeRequest();
 
     String header = recordedRequest.getHeader("Authorization");
@@ -107,7 +107,7 @@ class HttpClientTestIT extends BaseTest {
             null,
             null,
             null,
-            Collections.singletonList(BearerAuthManager.BEARER_SCHEMA_KEYWORD)));
+            Collections.singletonList(bearerAuthManager.getSchema())));
 
     RecordedRequest recordedRequest = mockBackEnd.takeRequest();
 
@@ -149,7 +149,7 @@ class HttpClientTestIT extends BaseTest {
               null,
               null,
               null,
-              Collections.singletonList(BearerAuthManager.BEARER_SCHEMA_KEYWORD)));
+              Collections.singletonList(bearerAuthManager.getSchema())));
     } catch (ApiException ae) {
       // noop
     }

--- a/sample-app/src/main/java/com/sinch/sample/sms/deliveryReports/GetForNumber.java
+++ b/sample-app/src/main/java/com/sinch/sample/sms/deliveryReports/GetForNumber.java
@@ -12,7 +12,7 @@ public class GetForNumber extends BaseApplication {
 
   public static void main(String[] args) {
     try {
-      new Get().run();
+      new GetForNumber().run();
     } catch (Exception e) {
       LOGGER.severe(e.getMessage());
       e.printStackTrace();


### PR DESCRIPTION
Dissociate the OAS alias names for security schemes from the authorized scheme keyword  (https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml)


OAS files are having security table:
```
security:
  - BearerAuth: []
  - 
```
to be mapped to a `Security schemes` section
```
  securitySchemes:
    BearerAuth:
      type: http
      scheme: bearer
```
So `BearerAuth` is a free form string (from security) and `Bearer` have to be in list from https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml

Refactoring code  prepare next free form name coming from 'Verification': `Basic`(currently Numbers is using `BasicAuth`) and will authorized single AuthManager with different alias from OAS files
