### PR TITLE
Support application id/secret for Verification API authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ buildNumber.properties
 .classpath
 .idea
 *.iml
+
+sample-app/src/main/resources/config.properties

--- a/client/src/main/com/sinch/sdk/SinchClient.java
+++ b/client/src/main/com/sinch/sdk/SinchClient.java
@@ -189,7 +189,6 @@ public class SinchClient {
 
   private HttpClientApache getHttpClient() {
     if (null == httpClient || httpClient.isClosed()) {
-
       // TODO: by adding a setter, we could imagine having another HTTP client provided
       // programmatically or use
       //  configuration file referencing another class by name

--- a/client/src/main/com/sinch/sdk/auth/adapters/BasicAuthManager.java
+++ b/client/src/main/com/sinch/sdk/auth/adapters/BasicAuthManager.java
@@ -15,8 +15,12 @@ public class BasicAuthManager implements AuthManager {
   private final String keySecret;
 
   public BasicAuthManager(Configuration configuration) {
-    this.keyId = configuration.getKeyId();
-    this.keySecret = configuration.getKeySecret();
+    this(configuration.getKeyId(), configuration.getKeySecret());
+  }
+
+  public BasicAuthManager(String keyId, String keySecret) {
+    this.keyId = keyId;
+    this.keySecret = keySecret;
   }
 
   public String getSchema() {

--- a/client/src/main/com/sinch/sdk/auth/adapters/BearerAuthManager.java
+++ b/client/src/main/com/sinch/sdk/auth/adapters/BearerAuthManager.java
@@ -34,11 +34,20 @@ public class BearerAuthManager implements AuthManager {
   private String token;
 
   public BearerAuthManager(Configuration configuration, HttpMapper mapper, HttpClient httpClient) {
+    this(configuration.getKeyId(), configuration.getKeySecret(), configuration, mapper, httpClient);
+  }
+
+  public BearerAuthManager(
+      String keyId,
+      String keySecret,
+      Configuration configuration,
+      HttpMapper mapper,
+      HttpClient httpClient) {
     this.oAuthServer = configuration.getOAuthServer();
     this.mapper = mapper;
     this.httpClient = httpClient;
 
-    AuthManager basicAuthManager = new BasicAuthManager(configuration);
+    AuthManager basicAuthManager = new BasicAuthManager(keyId, keySecret);
     authManagers =
         Stream.of(new AbstractMap.SimpleEntry<>(SCHEMA_KEYWORD_BASIC, basicAuthManager))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/client/src/main/com/sinch/sdk/domains/verification/VerificationService.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/VerificationService.java
@@ -11,14 +11,14 @@ public interface VerificationService {
 
   /**
    * Use application secret in place of unified configuration for authentication (see Sinch
-   * dashboard for details)
+   * dashboard for details) These credentials are related to Verification Apps
    *
-   * @param key see <a href="https://dashboard.sinch.com/voice/apps">dashboard</a>
-   * @param secret see <a href="https://dashboard.sinch.com/voice/apps">dashboard</a>
+   * @param key see <a href="https://dashboard.sinch.com/verification/apps">dashboard</a>
+   * @param secret see <a href="https://dashboard.sinch.com/verification/apps">dashboard</a>
    * @return service instance for project
    * @since 1.0
    */
-  VerificationService useSecrets(String key, String secret);
+  VerificationService setApplicationCredentials(String key, String secret);
 
   /**
    * Verifications Service instance

--- a/client/src/main/com/sinch/sdk/domains/verification/VerificationService.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/VerificationService.java
@@ -10,6 +10,17 @@ package com.sinch.sdk.domains.verification;
 public interface VerificationService {
 
   /**
+   * Use application secret in place of unified configuration for authentication (see Sinch
+   * dashboard for details)
+   *
+   * @param key see <a href="https://dashboard.sinch.com/voice/apps">dashboard</a>
+   * @param secret see <a href="https://dashboard.sinch.com/voice/apps">dashboard</a>
+   * @return service instance for project
+   * @since 1.0
+   */
+  VerificationService useSecrets(String key, String secret);
+
+  /**
    * Verifications Service instance
    *
    * @return service instance for project

--- a/client/src/main/com/sinch/sdk/domains/verification/adapters/StatusService.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/adapters/StatusService.java
@@ -14,22 +14,29 @@ import com.sinch.sdk.domains.verification.models.VerificationReference;
 import com.sinch.sdk.domains.verification.models.VerificationReport;
 import com.sinch.sdk.models.Configuration;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class StatusService implements com.sinch.sdk.domains.verification.StatusService {
 
-  private QueryVerificationsApi api;
-
-  public StatusService() {}
+  private final Configuration configuration;
+  private final HttpClient httpClient;
+  private final Supplier<Map<String, AuthManager>> authManagerSupplier;
 
   public StatusService(
-      Configuration configuration, HttpClient httpClient, Map<String, AuthManager> authManager) {
-    this.api =
-        new QueryVerificationsApi(
-            httpClient, configuration.getVerificationServer(), authManager, new HttpMapper());
+      Configuration configuration,
+      HttpClient httpClient,
+      Supplier<Map<String, AuthManager>> authManagerSupplier) {
+    this.configuration = configuration;
+    this.httpClient = httpClient;
+    this.authManagerSupplier = authManagerSupplier;
   }
 
-  private QueryVerificationsApi getApi() {
-    return this.api;
+  protected QueryVerificationsApi getApi() {
+    return new QueryVerificationsApi(
+        httpClient,
+        configuration.getVerificationServer(),
+        authManagerSupplier.get(),
+        new HttpMapper());
   }
 
   public VerificationReport get(Identity identity, VerificationMethodType method) {

--- a/client/src/main/com/sinch/sdk/domains/verification/adapters/VerificationsService.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/adapters/VerificationsService.java
@@ -15,23 +15,30 @@ import com.sinch.sdk.domains.verification.models.requests.VerificationReportRequ
 import com.sinch.sdk.domains.verification.models.response.StartVerificationResponse;
 import com.sinch.sdk.models.Configuration;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class VerificationsService
     implements com.sinch.sdk.domains.verification.VerificationsService {
 
-  private SendingAndReportingVerificationsApi api;
-
-  public VerificationsService() {}
+  private final Configuration configuration;
+  private final HttpClient httpClient;
+  private final Supplier<Map<String, AuthManager>> authManagerSupplier;
 
   public VerificationsService(
-      Configuration configuration, HttpClient httpClient, Map<String, AuthManager> authManager) {
-    this.api =
-        new SendingAndReportingVerificationsApi(
-            httpClient, configuration.getVerificationServer(), authManager, new HttpMapper());
+      Configuration configuration,
+      HttpClient httpClient,
+      Supplier<Map<String, AuthManager>> authManagerSupplier) {
+    this.configuration = configuration;
+    this.httpClient = httpClient;
+    this.authManagerSupplier = authManagerSupplier;
   }
 
-  private SendingAndReportingVerificationsApi getApi() {
-    return this.api;
+  protected SendingAndReportingVerificationsApi getApi() {
+    return new SendingAndReportingVerificationsApi(
+        httpClient,
+        configuration.getVerificationServer(),
+        authManagerSupplier.get(),
+        new HttpMapper());
   }
 
   public StartVerificationResponse start(StartVerificationRequestParameters parameters) {

--- a/client/src/main/com/sinch/sdk/http/HttpClientApache.java
+++ b/client/src/main/com/sinch/sdk/http/HttpClientApache.java
@@ -232,6 +232,7 @@ public class HttpClientApache implements com.sinch.sdk.core.http.HttpClient {
       Map<String, AuthManager> authManagersByOasSecuritySchemes,
       Collection<String> values,
       String body) {
+
     if (null == values || values.isEmpty() || null == authManagersByOasSecuritySchemes) {
       return;
     }

--- a/client/src/test/java/com/sinch/sdk/domains/verification/adapters/StatusServiceTest.java
+++ b/client/src/test/java/com/sinch/sdk/domains/verification/adapters/StatusServiceTest.java
@@ -1,11 +1,15 @@
 package com.sinch.sdk.domains.verification.adapters;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.adelean.inject.resources.junit.jupiter.TestWithResources;
 import com.sinch.sdk.BaseTest;
 import com.sinch.sdk.core.exceptions.ApiException;
+import com.sinch.sdk.core.http.AuthManager;
+import com.sinch.sdk.core.http.HttpClient;
 import com.sinch.sdk.domains.verification.adapters.api.v1.QueryVerificationsApi;
 import com.sinch.sdk.domains.verification.adapters.converters.VerificationsDtoConverterTest;
 import com.sinch.sdk.domains.verification.models.NumberIdentity;
@@ -15,17 +19,28 @@ import com.sinch.sdk.domains.verification.models.VerificationReference;
 import com.sinch.sdk.domains.verification.models.VerificationReport;
 import com.sinch.sdk.domains.verification.models.dto.v1.VerificationReportDtoTest;
 import com.sinch.sdk.models.Configuration;
+import java.util.Map;
+import java.util.function.Supplier;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 @TestWithResources
 public class StatusServiceTest extends BaseTest {
 
-  @Mock Configuration configuration;
   @Mock QueryVerificationsApi api;
-  @InjectMocks StatusService service;
+  @Mock Configuration configuration;
+  @Mock HttpClient httpClient;
+  @Mock Supplier<Map<String, AuthManager>> authManagerSupplier;
+
+  StatusService service;
+
+  @BeforeEach
+  public void initMocks() {
+    service = spy(new StatusService(configuration, httpClient, authManagerSupplier));
+    doReturn(api).when(service).getApi();
+  }
 
   @Test
   void getByIdentity() throws ApiException {

--- a/client/src/test/java/com/sinch/sdk/domains/verification/adapters/VerificationsServiceTest.java
+++ b/client/src/test/java/com/sinch/sdk/domains/verification/adapters/VerificationsServiceTest.java
@@ -1,12 +1,16 @@
 package com.sinch.sdk.domains.verification.adapters;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.adelean.inject.resources.junit.jupiter.GivenJsonResource;
 import com.adelean.inject.resources.junit.jupiter.TestWithResources;
 import com.sinch.sdk.BaseTest;
 import com.sinch.sdk.core.exceptions.ApiException;
+import com.sinch.sdk.core.http.AuthManager;
+import com.sinch.sdk.core.http.HttpClient;
 import com.sinch.sdk.domains.verification.adapters.api.v1.SendingAndReportingVerificationsApi;
 import com.sinch.sdk.domains.verification.adapters.converters.VerificationsDtoConverterTest;
 import com.sinch.sdk.domains.verification.models.NumberIdentity;
@@ -18,9 +22,11 @@ import com.sinch.sdk.domains.verification.models.dto.v1.VerificationReportDtoTes
 import com.sinch.sdk.domains.verification.models.dto.v1.VerificationReportRequestResourceDto;
 import com.sinch.sdk.domains.verification.models.response.StartVerificationResponse;
 import com.sinch.sdk.models.Configuration;
+import java.util.Map;
+import java.util.function.Supplier;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 @TestWithResources
@@ -32,9 +38,18 @@ public class VerificationsServiceTest extends BaseTest {
   @GivenJsonResource("/domains/verification/v1/VerificationReportCalloutRequestDto.json")
   public VerificationReportRequestResourceDto verificationReportRequestResourceDto;
 
-  @Mock Configuration configuration;
   @Mock SendingAndReportingVerificationsApi api;
-  @InjectMocks VerificationsService service;
+  @Mock Configuration configuration;
+  @Mock HttpClient httpClient;
+  @Mock Supplier<Map<String, AuthManager>> authManagerSupplier;
+
+  VerificationsService service;
+
+  @BeforeEach
+  public void initMocks() {
+    service = spy(new VerificationsService(configuration, httpClient, authManagerSupplier));
+    doReturn(api).when(service).getApi();
+  }
 
   @Test
   void start() throws ApiException {

--- a/sample-app/README.md
+++ b/sample-app/README.md
@@ -49,7 +49,6 @@ See https://developers.sinch.com for details about these parameters
 
 ## Available samples classes
 
-<<<<<<< HEAD
 ### Full workflow
 A full application chaining calls to Numbers service to onboard onto Java SDK and Numbers: [NumbersSampleFlow](src/main/java/com/sinch/sample/numbers/NumbersSampleFlow.java)
 
@@ -68,7 +67,7 @@ A full application chaining calls to Numbers service to onboard onto Java SDK an
 |              |                | - Update               | [com.sinch.sample.numbers.active.Update](src/main/java/com/sinch/sample/numbers/active/Update.java)                                                   | Require `PHONE_NUMBER` parameter                  |
 |              | Callback       | - Get                  | [com.sinch.sample.numbers.callback.Get](src/main/java/com/sinch/sample/numbers/callback/Get.java)                                                     |                                                   |
 |              |                | - Update               | [com.sinch.sample.numbers.callback.Update](src/main/java/com/sinch/sample/numbers/callback/Get.java)                                                  |                                                   |
-|              | Regions        | - ListAll              | [com.sinch.sample.numbers.regions.ListAll](src/main/java/com/sinch/sample/numbers/regions/ListAll.java)                                               |                                                   |
+|              | Regions        | - ListAll              | [com.sinch.sample.numbers.regions.List](src/main/java/com/sinch/sample/numbers/regions/List.java)                                               |                                                   |
 | SMS          | Batches        | - Get                  | [com.sinch.sample.sms.batches.Get](src/main/java/com/sinch/sample/sms/batches/Get.java)                                                               | Require `BATCH_ID` parameter                      |
 |              |                | - List                 | [com.sinch.sample.sms.batches.List](src/main/java/com/sinch/sample/sms/batches/List.java)                                                             |                                                   |
 |              |                | - Send                 | [com.sinch.sample.sms.batches.Send](src/main/java/com/sinch/sample/sms/batches/Send.java)                                                             |                                                   |

--- a/sample-app/src/main/java/com/sinch/sample/BaseApplication.java
+++ b/sample-app/src/main/java/com/sinch/sample/BaseApplication.java
@@ -7,13 +7,17 @@ import java.util.Properties;
 import java.util.logging.Logger;
 
 public abstract class BaseApplication {
-
   private static final String BATCH_ID_KEY = "BATCH_ID";
   private static final String PHONE_NUMBER_KEY = "PHONE_NUMBER";
 
   protected static final Logger LOGGER = Utils.initializeLogger(BaseApplication.class.getName());
 
+  // can super sed unified Sinch credentials if defined
+  private static final String VERIFICATION_API_KEY = "VERIFICATION_API_KEY";
+  private static final String VERIFICATION_API_SECRET = "VERIFICATION_API_SECRET";
+
   protected SinchClient client;
+
   protected String phoneNumber;
   protected String batchId;
 
@@ -34,6 +38,25 @@ public abstract class BaseApplication {
             : properties.getProperty(BATCH_ID_KEY);
 
     client = new SinchClient(configuration);
+
+    handleVerificationCredentials(client, properties);
+  }
+
+  void handleVerificationCredentials(SinchClient client, Properties props) {
+
+    String verificationApiKey =
+        null != System.getenv(VERIFICATION_API_KEY)
+            ? System.getenv(VERIFICATION_API_KEY)
+            : props.getProperty(VERIFICATION_API_KEY);
+    String verificationApiSecret =
+        null != System.getenv(VERIFICATION_API_SECRET)
+            ? System.getenv(VERIFICATION_API_SECRET)
+            : props.getProperty(VERIFICATION_API_SECRET);
+
+    // super-sed unified key/secret for verification API
+    if (null != verificationApiKey && null != verificationApiSecret) {
+      client.verification().useSecrets(verificationApiKey, verificationApiSecret);
+    }
   }
 
   public abstract void run();

--- a/sample-app/src/main/java/com/sinch/sample/BaseApplication.java
+++ b/sample-app/src/main/java/com/sinch/sample/BaseApplication.java
@@ -55,7 +55,7 @@ public abstract class BaseApplication {
 
     // super-sed unified key/secret for verification API
     if (null != verificationApiKey && null != verificationApiSecret) {
-      client.verification().useSecrets(verificationApiKey, verificationApiSecret);
+      client.verification().setApplicationCredentials(verificationApiKey, verificationApiSecret);
     }
   }
 


### PR DESCRIPTION
Note the `useSecrets` function defined at Verification service level;
The sample application is calling it only if dedicated Verification config is set.
Then, the sinchclient Verification calls are using a single client instance able to use Numbers/Sms or Verification without any changes.
So when Verification API will support unified credentials: just removing the call to `useSecrets` (so removing dedicated config) and Sinch credentials will be used.
No mode side effects