### PR TITLE
DEVEXP-111: add User-Agent SDK header

### DIFF
--- a/client/resources/version.properties
+++ b/client/resources/version.properties
@@ -1,0 +1,4 @@
+project.version=${project.version}
+project.name=${project.name}
+project.auxiliary_flag=
+project.java.version=${maven.compiler.source}

--- a/client/resources/version.properties
+++ b/client/resources/version.properties
@@ -1,4 +1,3 @@
 project.version=${project.version}
 project.name=${project.name}
 project.auxiliary_flag=
-project.java.version=${maven.compiler.source}

--- a/client/src/main/com/sinch/sdk/SinchClient.java
+++ b/client/src/main/com/sinch/sdk/SinchClient.java
@@ -35,7 +35,6 @@ public class SinchClient {
 
   private static final String PROJECT_NAME_KEY = "project.name";
   private static final String PROJECT_VERSION_KEY = "project.version";
-  private static final String PROJECT_JAVA_VERSION_KEY = "project.java.version";
   private static final String PROJECT_AUXILIARY_FLAG = "project.auxiliary_flag";
 
   // sinch-sdk/{sdk_version} ({language}/{language_version}; {implementation_type};
@@ -198,15 +197,14 @@ public class SinchClient {
         SDK_USER_AGENT_FORMAT,
         versionProperties.get(PROJECT_VERSION_KEY),
         "Java",
-        versionProperties.get(PROJECT_JAVA_VERSION_KEY),
+        System.getProperty("java.version"),
         "Apache",
         formatAuxiliaryFlag((String) versionProperties.get(PROJECT_AUXILIARY_FLAG)));
   }
 
   private String formatAuxiliaryFlag(String auxiliaryFlag) {
 
-    Collection<String> values =
-        Arrays.asList(System.getProperty("java.vendor"), System.getProperty("java.version"));
+    Collection<String> values = Arrays.asList(System.getProperty("java.vendor"));
 
     if (!StringUtil.isEmpty(auxiliaryFlag)) {
       values.add(auxiliaryFlag);

--- a/client/src/main/com/sinch/sdk/SinchClient.java
+++ b/client/src/main/com/sinch/sdk/SinchClient.java
@@ -4,6 +4,7 @@ import com.sinch.sdk.auth.AuthManager;
 import com.sinch.sdk.auth.adapters.BasicAuthManager;
 import com.sinch.sdk.auth.adapters.BearerAuthManager;
 import com.sinch.sdk.core.http.HttpMapper;
+import com.sinch.sdk.core.utils.StringUtil;
 import com.sinch.sdk.domains.numbers.NumbersService;
 import com.sinch.sdk.domains.sms.SMSService;
 import com.sinch.sdk.http.HttpClientApache;
@@ -12,6 +13,8 @@ import com.sinch.sdk.models.SMSRegion;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -22,14 +25,28 @@ import java.util.stream.Stream;
 /** Sinch Sdk Client implementation */
 public class SinchClient {
 
+  private static final String DEFAULT_PROPERTIES_FILE_NAME = "/config-default.properties";
+  private static final String VERSION_PROPERTIES_FILE_NAME = "/version.properties";
+
   private static final String OAUTH_URL_KEY = "oauth-url";
   private static final String NUMBERS_SERVER_KEY = "numbers-server";
   private static final String SMS_REGION_KEY = "sms-region";
   private static final String SMS_SERVER_KEY = "sms-server";
 
+  private static final String PROJECT_NAME_KEY = "project.name";
+  private static final String PROJECT_VERSION_KEY = "project.version";
+  private static final String PROJECT_JAVA_VERSION_KEY = "project.java.version";
+  private static final String PROJECT_AUXILIARY_FLAG = "project.auxiliary_flag";
+
+  // sinch-sdk/{sdk_version} ({language}/{language_version}; {implementation_type};
+  // {auxiliary_flag})
+  private static final String SDK_USER_AGENT_HEADER = "User-Agent";
+  private static final String SDK_USER_AGENT_FORMAT = "sinch-sdk/%s (%s/%s; %s; %s)";
   private static final Logger LOGGER = Logger.getLogger(SinchClient.class.getName());
 
   private final Configuration configuration;
+  private final Properties versionProperties;
+
   private NumbersService numbers;
 
   private SMSService sms;
@@ -46,7 +63,7 @@ public class SinchClient {
 
     Configuration.Builder builder = Configuration.builder(configuration);
 
-    Properties props = handleDefaultConfigurationFile();
+    Properties props = handlePropertiesFile(DEFAULT_PROPERTIES_FILE_NAME);
     if (null == configuration.getOAuthUrl() && props.containsKey(OAUTH_URL_KEY)) {
       builder.setOAuthUrl(props.getProperty(OAUTH_URL_KEY));
     }
@@ -63,7 +80,13 @@ public class SinchClient {
     checkConfiguration(newConfiguration);
     this.configuration = newConfiguration;
 
-    LOGGER.fine("SinchClient started with projectId='" + configuration.getProjectId() + "'");
+    versionProperties = handlePropertiesFile(VERSION_PROPERTIES_FILE_NAME);
+    LOGGER.fine(
+        String.format(
+            "%s (%s) started with projectId '%s'",
+            versionProperties.getProperty(PROJECT_NAME_KEY),
+            versionProperties.getProperty(PROJECT_VERSION_KEY),
+            configuration.getProjectId()));
   }
 
   /**
@@ -130,10 +153,10 @@ public class SinchClient {
     return new com.sinch.sdk.domains.sms.adapters.SMSService(getConfiguration(), getHttpClient());
   }
 
-  private Properties handleDefaultConfigurationFile() {
+  private Properties handlePropertiesFile(String fileName) {
 
     Properties prop = new Properties();
-    try (InputStream is = this.getClass().getResourceAsStream("/config-default.properties")) {
+    try (InputStream is = this.getClass().getResourceAsStream(fileName)) {
       prop.load(is);
     } catch (IOException e) {
       // NOOP
@@ -159,8 +182,35 @@ public class SinchClient {
       // Avoid multiple and costly http client creation and reuse it for authManager
       bearerAuthManager.setHttpClient(this.httpClient);
 
+      // set SDK User-Agent
+      String userAgent = formatSdkUserAgentHeader(versionProperties);
+      this.httpClient.setRequestHeaders(
+          Stream.of(new String[][] {{SDK_USER_AGENT_HEADER, userAgent}})
+              .collect(Collectors.toMap(data -> data[0], data -> data[1])));
+
       LOGGER.fine("HTTP client loaded");
     }
     return this.httpClient;
+  }
+
+  private String formatSdkUserAgentHeader(Properties versionProperties) {
+    return String.format(
+        SDK_USER_AGENT_FORMAT,
+        versionProperties.get(PROJECT_VERSION_KEY),
+        "Java",
+        versionProperties.get(PROJECT_JAVA_VERSION_KEY),
+        "Apache",
+        formatAuxiliaryFlag((String) versionProperties.get(PROJECT_AUXILIARY_FLAG)));
+  }
+
+  private String formatAuxiliaryFlag(String auxiliaryFlag) {
+
+    Collection<String> values =
+        Arrays.asList(System.getProperty("java.vendor"), System.getProperty("java.version"));
+
+    if (!StringUtil.isEmpty(auxiliaryFlag)) {
+      values.add(auxiliaryFlag);
+    }
+    return String.join(",", values);
   }
 }

--- a/client/src/main/com/sinch/sdk/domains/sms/models/BaseBatch.java
+++ b/client/src/main/com/sinch/sdk/domains/sms/models/BaseBatch.java
@@ -70,10 +70,6 @@ public class BaseBatch<T> {
     this.feedbackEnabled = feedbackEnabled;
   }
 
-  public static <T> BatchBuilder<T> batchBuilder() {
-    return new BatchBuilder<>();
-  }
-
   public Collection<String> getTo() {
     return to;
   }

--- a/client/src/main/com/sinch/sdk/http/HttpClientApache.java
+++ b/client/src/main/com/sinch/sdk/http/HttpClientApache.java
@@ -26,11 +26,17 @@ public class HttpClientApache implements com.sinch.sdk.core.http.HttpClient {
   private static final Logger LOGGER = Logger.getLogger(HttpClientApache.class.getName());
   private static final String AUTHORIZATION_HEADER_KEYWORD = "Authorization";
   private final Map<String, AuthManager> authManagers;
+
+  private Map<String, String> headersToBeAdded;
   private CloseableHttpClient client;
 
   public HttpClientApache(Map<String, AuthManager> authManagers) {
     this.client = HttpClients.createDefault();
     this.authManagers = authManagers;
+  }
+
+  public void setRequestHeaders(Map<String, String> headers) {
+    this.headersToBeAdded = headers;
   }
 
   private static HttpResponse processResponse(ClassicHttpResponse response) throws IOException {
@@ -97,6 +103,9 @@ public class HttpClientApache implements com.sinch.sdk.core.http.HttpClient {
 
       addCollectionHeader(requestBuilder, "Content-Type", contentType);
       addCollectionHeader(requestBuilder, "Accept", accept);
+
+      addHeaders(requestBuilder, headerParams);
+      addHeaders(requestBuilder, headersToBeAdded);
 
       addAuth(requestBuilder, authNames);
 
@@ -167,6 +176,17 @@ public class HttpClientApache implements com.sinch.sdk.core.http.HttpClient {
     if (null != values && !values.isEmpty()) {
       requestBuilder.setHeader(header, String.join(",", values));
     }
+  }
+
+  private void addHeaders(ClassicRequestBuilder requestBuilder, Map<String, String> headers) {
+
+    if (null == headers) {
+      return;
+    }
+    headers
+        .entrySet()
+        .iterator()
+        .forEachRemaining(f -> requestBuilder.setHeader(f.getKey(), f.getValue()));
   }
 
   private void addAuth(ClassicRequestBuilder requestBuilder, Collection<String> values) {

--- a/client/src/test/java/com/sinch/sdk/SinchClientTestIT.java
+++ b/client/src/test/java/com/sinch/sdk/SinchClientTestIT.java
@@ -1,0 +1,57 @@
+package com.sinch.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.adelean.inject.resources.junit.jupiter.TestWithResources;
+import com.sinch.sdk.core.exceptions.ApiException;
+import com.sinch.sdk.models.Configuration;
+import java.io.IOException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@TestWithResources
+class SinchClientTestIT extends BaseTest {
+  static MockWebServer mockBackEnd;
+  String serverUrl = String.format("http://localhost:%s", mockBackEnd.getPort());
+
+  Configuration configuration =
+      Configuration.builder()
+          .setKeyId("foo")
+          .setKeySecret("foo")
+          .setProjectId("foo")
+          .setNumbersUrl(serverUrl)
+          .build();
+
+  SinchClient sinchClient = new SinchClient(configuration);
+
+  @BeforeAll
+  static void classSetUp() throws IOException {
+    mockBackEnd = new MockWebServer();
+    mockBackEnd.start();
+  }
+
+  @AfterAll
+  static void tearDown() throws IOException {
+    mockBackEnd.shutdown();
+  }
+
+  @Test
+  void sdkUserAgent() throws InterruptedException {
+
+    mockBackEnd.enqueue(
+        new MockResponse().setBody("foo").addHeader("Content-Type", "application/json"));
+
+    try {
+      sinchClient.numbers().available().checkAvailability("foo");
+    } catch (ApiException ae) {
+      // noop
+    }
+    RecordedRequest recordedRequest = mockBackEnd.takeRequest();
+    String header = recordedRequest.getHeader("User-Agent");
+    assertThat(header).matches("^sinch-sdk/.* \\(Java/.*; Apache; .*\\)$");
+  }
+}

--- a/client/src/test/java/com/sinch/sdk/core/adapters/apache/HttpClientTestIT.java
+++ b/client/src/test/java/com/sinch/sdk/core/adapters/apache/HttpClientTestIT.java
@@ -177,4 +177,50 @@ class HttpClientTestIT extends BaseTest {
     header = recordedRequest.getHeader("Authorization");
     assertEquals(header, "Bearer another token");
   }
+
+  @Test
+  void httpRequestHeaders() throws InterruptedException {
+    String key = "My-OAS-Header-Key";
+    String value = "OAS Header Value";
+    Map<String, String> httpRequest =
+        Stream.of(new String[][] {{key, value}})
+            .collect(Collectors.toMap(data -> data[0], data -> data[1]));
+
+    mockBackEnd.enqueue(
+        new MockResponse().setBody("foo").addHeader("Content-Type", "application/json"));
+
+    try {
+      httpClient.invokeAPI(
+          new ServerConfiguration(String.format("%s/foo/", serverUrl)),
+          new HttpRequest("foo-path", HttpMethod.GET, null, null, httpRequest, null, null, null));
+    } catch (ApiException ae) {
+      // noop
+    }
+    RecordedRequest recordedRequest = mockBackEnd.takeRequest();
+    String header = recordedRequest.getHeader(key);
+    assertEquals(header, value);
+  }
+
+  @Test
+  void sdkHeaders() throws InterruptedException {
+    String key = "My-Sdk-Header-Key";
+    String value = "SDK Header Value";
+    httpClient.setRequestHeaders(
+        Stream.of(new String[][] {{key, value}})
+            .collect(Collectors.toMap(data -> data[0], data -> data[1])));
+
+    mockBackEnd.enqueue(
+        new MockResponse().setBody("foo").addHeader("Content-Type", "application/json"));
+
+    try {
+      httpClient.invokeAPI(
+          new ServerConfiguration(String.format("%s/foo/", serverUrl)),
+          new HttpRequest("foo-path", HttpMethod.GET, null, null, null, null, null, null));
+    } catch (ApiException ae) {
+      // noop
+    }
+    RecordedRequest recordedRequest = mockBackEnd.takeRequest();
+    String header = recordedRequest.getHeader(key);
+    assertEquals(header, value);
+  }
 }

--- a/core/src/main/com/sinch/sdk/core/http/HttpClient.java
+++ b/core/src/main/com/sinch/sdk/core/http/HttpClient.java
@@ -2,12 +2,20 @@ package com.sinch.sdk.core.http;
 
 import com.sinch.sdk.core.exceptions.ApiException;
 import com.sinch.sdk.core.models.ServerConfiguration;
+import java.util.Map;
 
 public interface HttpClient extends AutoCloseable {
 
   boolean isClosed();
 
   void close() throws Exception;
+
+  /**
+   * Register a set of headers to be added onto requests
+   *
+   * @param headers Map of key/value headers to be added
+   */
+  void setRequestHeaders(Map<String, String> headers);
 
   HttpResponse invokeAPI(ServerConfiguration serverConfiguration, HttpRequest request)
       throws ApiException;

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,12 @@
     </properties>
 
     <build>
+        <resources>
+            <resource>
+                <directory>client/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
 
         <pluginManagement>
             <plugins>
@@ -372,6 +378,12 @@
             <artifactId>mockwebserver</artifactId>
             <version>4.12.0</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>3.9.5</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Sending SDK User-Agent header.
Format will be: `sinch-sdk/{sdk_version} ({language}/{language_version}; {implementation_type}; {auxiliary_flag})`

Where:
- `sdk_version`: Version according to release/deployment version
- `language`: hard coded to `Java`
- `language_version`: java compiler version set for sources
- `implementation_type`: Currently only `Apache` for HTTP Apache client is supported
- `auxiliary_flag`: Comma separated list containing information about JVM used for SinchClient execution:
   - `java.vendor`  
   - `java.version`

Example of generated header: `User-Agent: sinch-sdk/0.0.1-SNAPSHOT (Java/1.8; Apache; AdoptOpenJDK,14.0.2)`