### PR TITLE
feat: fix security alert related to 'com.squareup.okio:okio' version '>= 2.0.0-RC1 < 3.4.0'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -363,7 +363,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.11.0</version>
+            <version>4.12.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Upgrade com.squareup.okhttp3 version to remove dependency onto package firing security alert 
New dependency version: `3.6.0`
```
mvn dependency:tree
...
[INFO] +- com.squareup.okhttp3:okhttp:jar:4.12.0:test
[INFO] |  +- com.squareup.okio:okio:jar:3.6.0:test
[INFO] |  |  \- com.squareup.okio:okio-jvm:jar:3.6.0:test
...
```