### PR TITLE
Java 21 JDK compilation support

### DIFF
--- a/client/src/main/com/sinch/sdk/SinchClient.java
+++ b/client/src/main/com/sinch/sdk/SinchClient.java
@@ -21,7 +21,7 @@ import java.util.stream.Stream;
 public class SinchClient {
 
   private static final String DEFAULT_PROPERTIES_FILE_NAME = "/config-default.properties";
-       private static final String VERSION_PROPERTIES_FILE_NAME = "/version.properties";
+  private static final String VERSION_PROPERTIES_FILE_NAME = "/version.properties";
 
   private static final String OAUTH_URL_KEY = "oauth-url";
   private static final String NUMBERS_SERVER_KEY = "numbers-server";
@@ -224,5 +224,4 @@ public class SinchClient {
     }
     return String.join(",", values);
   }
-
 }

--- a/client/src/main/com/sinch/sdk/auth/models/BearerAuthResponse.java
+++ b/client/src/main/com/sinch/sdk/auth/models/BearerAuthResponse.java
@@ -19,7 +19,9 @@ public class BearerAuthResponse {
     return accessToken;
   }
 
-  /** @return Integer Token period expiration in seconds */
+  /**
+   * @return Integer Token period expiration in seconds
+   */
   public Integer getExpiresIn() {
     return expiresIn;
   }

--- a/client/src/main/com/sinch/sdk/domains/numbers/models/NumberType.java
+++ b/client/src/main/com/sinch/sdk/domains/numbers/models/NumberType.java
@@ -14,6 +14,7 @@ public final class NumberType extends EnumDynamic<String, NumberType> {
 
   /** Numbers that belong to a specific range. */
   public static final NumberType MOBILE = new NumberType("MOBILE");
+
   /** Numbers that are assigned to a specific geographic region. */
   public static final NumberType LOCAL = new NumberType("LOCAL");
 

--- a/client/src/main/com/sinch/sdk/domains/numbers/models/OrderBy.java
+++ b/client/src/main/com/sinch/sdk/domains/numbers/models/OrderBy.java
@@ -13,6 +13,7 @@ import java.util.stream.Stream;
 public final class OrderBy extends EnumDynamic<String, OrderBy> {
   /** Ordering by phoneNumber */
   public static final OrderBy PHONE_NUMBER = new OrderBy("phoneNumber");
+
   /** Ordering by displayName */
   public static final OrderBy DISPLAY_NAME = new OrderBy("displayName");
 

--- a/client/src/main/com/sinch/sdk/domains/numbers/models/SearchPattern.java
+++ b/client/src/main/com/sinch/sdk/domains/numbers/models/SearchPattern.java
@@ -19,10 +19,12 @@ public final class SearchPattern extends EnumDynamic<String, SearchPattern> {
    * <p>For example, to search for area code 206 in the US, you would enter, %2b1206
    */
   public static final SearchPattern START = new SearchPattern("START");
+
   /**
    * The number pattern entered is contained somewhere in the number, the location being undefined.
    */
   public static final SearchPattern CONTAINS = new SearchPattern("CONTAINS");
+
   /** The number ends with the number pattern entered. */
   public static final SearchPattern END = new SearchPattern("END");
 

--- a/client/src/main/com/sinch/sdk/domains/numbers/models/requests/AvailableRegionListAllRequestParameters.java
+++ b/client/src/main/com/sinch/sdk/domains/numbers/models/requests/AvailableRegionListAllRequestParameters.java
@@ -15,7 +15,9 @@ public class AvailableRegionListAllRequestParameters {
 
   private final Collection<NumberType> types;
 
-  /** @param types Only return regions for which numbers are provided with the given types */
+  /**
+   * @param types Only return regions for which numbers are provided with the given types
+   */
   public AvailableRegionListAllRequestParameters(Collection<NumberType> types) {
     this.types = types;
   }

--- a/client/src/main/com/sinch/sdk/domains/numbers/models/requests/CallbackConfigurationUpdateRequestParameters.java
+++ b/client/src/main/com/sinch/sdk/domains/numbers/models/requests/CallbackConfigurationUpdateRequestParameters.java
@@ -11,7 +11,9 @@ public class CallbackConfigurationUpdateRequestParameters {
   /** */
   private final String hmacSecret;
 
-  /** @param hmacSecret The HMAC secret to be updated for the specified project */
+  /**
+   * @param hmacSecret The HMAC secret to be updated for the specified project
+   */
   public CallbackConfigurationUpdateRequestParameters(String hmacSecret) {
     this.hmacSecret = hmacSecret;
   }

--- a/client/src/main/com/sinch/sdk/domains/sms/models/DeliveryReportErrorCode.java
+++ b/client/src/main/com/sinch/sdk/domains/sms/models/DeliveryReportErrorCode.java
@@ -19,63 +19,80 @@ public class DeliveryReportErrorCode extends EnumDynamic<Integer, DeliveryReport
    * account.
    */
   public static final DeliveryReportErrorCode QUEUED = new DeliveryReportErrorCode(400);
+
   /** Message has been dispatched to SMSC. */
   public static final DeliveryReportErrorCode DISPATCHED = new DeliveryReportErrorCode(401);
+
   /** SMSC rejected message. Retrying is likely to cause the same error. */
   public static final DeliveryReportErrorCode MESSAGE_UNROUTABLE = new DeliveryReportErrorCode(402);
+
   /** An unexpected error caused the message to fail. */
   public static final DeliveryReportErrorCode INTERNAL_ERROR = new DeliveryReportErrorCode(403);
+
   /** Message failed because of temporary delivery failure. Message can be retried. */
   public static final DeliveryReportErrorCode TEMPORARY_DELIVERY_FAILURE =
       new DeliveryReportErrorCode(404);
+
   /**
    * One or more parameters in the message body has no mapping for this recipient. See Message
    * Parameterization
    */
   public static final DeliveryReportErrorCode UNMATCHED_PARAMETER =
       new DeliveryReportErrorCode(405);
+
   /**
    * Message was expired before reaching SMSC. This may happen if the expiry time for the message
    * was very short.
    */
   public static final DeliveryReportErrorCode INTERNAL_EXPIRY = new DeliveryReportErrorCode(406);
+
   /** Message was cancelled by user before reaching SMSC. */
   public static final DeliveryReportErrorCode CANCELLED = new DeliveryReportErrorCode(407);
+
   /** SMSC rejected the message. Retrying is likely to cause the same error. */
   public static final DeliveryReportErrorCode INTERNAL_REJECT = new DeliveryReportErrorCode(408);
+
   /**
    * No default originator exists/configured for this recipient when sending message without
    * originator.
    */
   public static final DeliveryReportErrorCode UNMATCHED_DEFAULT_ORIGINATOR =
       new DeliveryReportErrorCode(410);
+
   /**
    * Message failed as the number of message parts exceeds the defined max number of message parts.
    */
   public static final DeliveryReportErrorCode EXCEEDED_PARTS_LIMIT =
       new DeliveryReportErrorCode(411);
+
   /** SMSC rejected the message. The account hasn't been provisioned for this region. */
   public static final DeliveryReportErrorCode UNPROVISIONED_REGION =
       new DeliveryReportErrorCode(412);
+
   /** The account is blocked. Reach out to support for help. Potentially out of credits. */
   public static final DeliveryReportErrorCode BLOCKED = new DeliveryReportErrorCode(413);
+
   /**
    * MMS only, the request failed due to a bad media URL. It is possible that the URL was
    * unreachable, or sent a bad response.
    */
   public static final DeliveryReportErrorCode BAD_MEDIA = new DeliveryReportErrorCode(414);
+
   /** MMS only, message reached MMSC but was rejected by MMS gateway or mobile network. */
   public static final DeliveryReportErrorCode DELIVERY_REPORT_REJECTED =
       new DeliveryReportErrorCode(415);
+
   /** MMS only, message reached MMSC but it is not supported. */
   public static final DeliveryReportErrorCode DELIVERY_REPORT_NOT_SUPPORTED =
       new DeliveryReportErrorCode(416);
+
   /**
    * MMS only, message reached MMSC but the destination network or the mobile subscriber cannot be
    * reached.
    */
   public static final DeliveryReportErrorCode DELIVERY_REPORT_UNREACHABLE =
       new DeliveryReportErrorCode(417);
+
   /**
    * MMS only, message reached MMSC but the handset of the mobile subscriber does not recognize the
    * message content.

--- a/client/src/main/com/sinch/sdk/domains/sms/models/DeliveryReportStatus.java
+++ b/client/src/main/com/sinch/sdk/domains/sms/models/DeliveryReportStatus.java
@@ -23,28 +23,37 @@ public class DeliveryReportStatus extends EnumDynamic<String, DeliveryReportStat
    * account.
    */
   public static final DeliveryReportStatus QUEUED = new DeliveryReportStatus("Queued");
+
   /** Message has been dispatched and accepted for delivery by the SMSC. */
   public static final DeliveryReportStatus DISPATCHED = new DeliveryReportStatus("Dispatched");
+
   /** Message was aborted before reaching the SMSC. */
   public static final DeliveryReportStatus ABORTED = new DeliveryReportStatus("Aborted");
+
   /** Message was cancelled by user before reaching SMSC. */
   public static final DeliveryReportStatus CANCELLED = new DeliveryReportStatus("Cancelled");
+
   /** Message was rejected by the SMSC. */
   public static final DeliveryReportStatus REJECTED = new DeliveryReportStatus("Rejected");
+
   /**
    * Message has been deleted. Message was deleted by a remote SMSC. This may happen if the
    * destination is an invalid MSISDN or opted out subscriber.
    */
   public static final DeliveryReportStatus DELETED = new DeliveryReportStatus("Deleted");
+
   /** Message has been delivered. */
   public static final DeliveryReportStatus DELIVERED = new DeliveryReportStatus("Delivered");
+
   /** Message failed to be delivered. */
   public static final DeliveryReportStatus FAILED = new DeliveryReportStatus("Failed");
+
   /**
    * Message expired before delivery to the SMSC. This may happen if the expiry time for the message
    * was very short.
    */
   public static final DeliveryReportStatus EXPIRED = new DeliveryReportStatus("Expired");
+
   /**
    * Message was delivered to the SMSC but no Delivery Receipt has been received or a Delivery
    * Receipt that couldn't be interpreted was received.

--- a/client/src/main/com/sinch/sdk/domains/sms/models/DeliveryReportType.java
+++ b/client/src/main/com/sinch/sdk/domains/sms/models/DeliveryReportType.java
@@ -14,19 +14,23 @@ public class DeliveryReportType extends EnumDynamic<String, DeliveryReportType> 
 
   /** No delivery report callback will be sent. */
   public static final DeliveryReportType NONE = new DeliveryReportType("none");
+
   /** A single delivery report callback will be sent. */
   public static final DeliveryReportType SUMMARY = new DeliveryReportType("summary");
+
   /**
    * A single delivery report callback will be sent which includes a list of recipients per delivery
    * status.
    */
   public static final DeliveryReportType FULL = new DeliveryReportType("full");
+
   /**
    * A delivery report callback will be sent for each status change of a message. This could result
    * in a lot of callbacks and should be used with caution for larger batches. These delivery
    * reports also include a timestamp of when the Delivery Report originated from the SMSC.
    */
   public static final DeliveryReportType PER_RECIPIENT = new DeliveryReportType("per_recipient");
+
   /**
    * A delivery report callback representing the final status of a message will be sent for each
    * recipient. This will send only one callback per recipient, compared to the multiple callbacks

--- a/client/src/main/com/sinch/sdk/domains/sms/models/requests/SendSmsBatchBinaryRequest.java
+++ b/client/src/main/com/sinch/sdk/domains/sms/models/requests/SendSmsBatchBinaryRequest.java
@@ -13,6 +13,7 @@ public class SendSmsBatchBinaryRequest extends BaseBatch<String> {
   private final Integer fromTon;
   private final Integer fromNpi;
   private final String udh;
+
   /**
    * @param to List of Phone numbers and group IDs that will receive the batch
    * @param from Sender number. Must be valid phone number, short code or alphanumeric. Required if

--- a/client/src/main/com/sinch/sdk/domains/sms/models/requests/SendSmsBatchTextRequest.java
+++ b/client/src/main/com/sinch/sdk/domains/sms/models/requests/SendSmsBatchTextRequest.java
@@ -14,6 +14,7 @@ public class SendSmsBatchTextRequest extends BaseBatch<String> {
   private final Integer maxNumberOfMessageParts;
   private final Integer fromTon;
   private final Integer fromNpi;
+
   /**
    * @param to List of Phone numbers and group IDs that will receive the batch
    * @param from Sender number. Must be valid phone number, short code or alphanumeric. Required if

--- a/client/src/main/com/sinch/sdk/domains/sms/models/requests/UpdateSmsBatchBinaryRequest.java
+++ b/client/src/main/com/sinch/sdk/domains/sms/models/requests/UpdateSmsBatchBinaryRequest.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 public class UpdateSmsBatchBinaryRequest extends UpdateBaseBatchRequest<String> {
   private final String udh;
+
   /**
    * @param toAdd List of phone numbers and group IDs to add to the batch.List of Phone numbers and
    *     group IDs that will receive the batch

--- a/client/src/main/com/sinch/sdk/domains/sms/models/requests/UpdateSmsBatchMediaRequest.java
+++ b/client/src/main/com/sinch/sdk/domains/sms/models/requests/UpdateSmsBatchMediaRequest.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 public class UpdateSmsBatchMediaRequest extends UpdateBaseBatchRequest<MediaBody> {
   private final Parameters parameters;
   private final Boolean strictValidation;
+
   /**
    * @param toAdd List of phone numbers and group IDs to add to the batch.
    * @param body The message content

--- a/client/src/main/com/sinch/sdk/domains/sms/models/requests/UpdateSmsBatchTextRequest.java
+++ b/client/src/main/com/sinch/sdk/domains/sms/models/requests/UpdateSmsBatchTextRequest.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 public class UpdateSmsBatchTextRequest extends UpdateBaseBatchRequest<String> {
   private final Parameters parameters;
+
   /**
    * @param toAdd List of phone numbers and group IDs to add to the batch.
    * @param toRemove List of phone numbers and group IDs to remove from the batch.

--- a/client/src/main/com/sinch/sdk/domains/verification/WebHooksService.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/WebHooksService.java
@@ -7,11 +7,11 @@ import java.util.Map;
 
 /**
  * Webhooks service
- *  <p>
- * Callback events are used to authorize and manage your verification requests and return
+ *
+ * <p>Callback events are used to authorize and manage your verification requests and return
  * verification results.
- * <p>
- * see <a
+ *
+ * <p>see <a
  * href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationRequestEvent/post">https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationRequestEvent/post</a>
  *
  * @since 1.0
@@ -22,16 +22,17 @@ public interface WebHooksService {
    * The Sinch Platform can initiate callback requests to a URL you define (Callback URL) on request
    * and result events. All callback requests are signed using your Application key and secret pair
    * found on your dashboard. The signature is included in the Authorization header of the request
-   * <p>By using following function, you can ensure authentication according to received payload
-   * from your backend</p>
    *
-   * @param method      The HTTP method used ot handle the callback
-   * @param path        The path to you backend endpoint used for callback
-   * @param headers     Received headers
+   * <p>By using following function, you can ensure authentication according to received payload
+   * from your backend
+   *
+   * @param method The HTTP method used ot handle the callback
+   * @param path The path to you backend endpoint used for callback
+   * @param headers Received headers
    * @param jsonPayload Received payload
    * @return Is authentication is validated (true) or not (false)
-   *
-   * see <a href="https://developers.sinch.com/docs/verification/api-reference/authentication/callback-signed-request">https://developers.sinch.com/docs/verification/api-reference/authentication/callback-signed-request</a>
+   *     <p>see <a
+   *     href="https://developers.sinch.com/docs/verification/api-reference/authentication/callback-signed-request">https://developers.sinch.com/docs/verification/api-reference/authentication/callback-signed-request</a>
    * @since 1.0
    */
   boolean checkAuthentication(
@@ -43,8 +44,8 @@ public interface WebHooksService {
    *
    * @param jsonPayload Received payload to be deserialized
    * @return The verification event instance class
-   *
-   * see <a href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/">https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/</a>
+   *     <p>see <a
+   *     href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/">https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/</a>
    * @since 1.0
    */
   VerificationEvent unserializeVerificationEvent(String jsonPayload) throws ApiMappingException;
@@ -54,9 +55,9 @@ public interface WebHooksService {
    *
    * @param response The response to be serialized
    * @return The JSON string to be sent
-   *
-   * see <a href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/">https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/</a>
-   *  @since 1.0
+   *     <p>see <a
+   *     href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/">https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/</a>
+   * @since 1.0
    */
   String serializeVerificationResponse(VerificationResponse response) throws ApiMappingException;
 }

--- a/client/src/main/com/sinch/sdk/domains/verification/adapters/StatusService.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/adapters/StatusService.java
@@ -20,14 +20,10 @@ public class StatusService implements com.sinch.sdk.domains.verification.StatusS
   private final QueryVerificationsApi api;
 
   public StatusService(
-      Configuration configuration,
-      HttpClient httpClient,
-     Map<String, AuthManager> authManagers) {
-    this.api =  new QueryVerificationsApi(
-        httpClient,
-        configuration.getVerificationServer(),
-        authManagers,
-        new HttpMapper());
+      Configuration configuration, HttpClient httpClient, Map<String, AuthManager> authManagers) {
+    this.api =
+        new QueryVerificationsApi(
+            httpClient, configuration.getVerificationServer(), authManagers, new HttpMapper());
   }
 
   protected QueryVerificationsApi getApi() {

--- a/client/src/main/com/sinch/sdk/domains/verification/adapters/VerificationService.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/adapters/VerificationService.java
@@ -31,14 +31,16 @@ public class VerificationService implements com.sinch.sdk.domains.verification.V
 
   public VerificationService(Configuration configuration, HttpClient httpClient) {
 
-    // Currently, we are not supporting unified credentials: ensure application credentials are defined
+    // Currently, we are not supporting unified credentials: ensure application credentials are
+    // defined
     Objects.requireNonNull(configuration.getApplicationKey(), "'applicationKey' cannot be null");
-    Objects.requireNonNull(configuration.getApplicationSecret(),
-        "'applicationSecret' cannot be null");
+    Objects.requireNonNull(
+        configuration.getApplicationSecret(), "'applicationSecret' cannot be null");
 
     this.configuration = configuration;
     this.httpClient = httpClient;
-    setApplicationCredentials(configuration.getApplicationKey(),configuration.getApplicationSecret() );
+    setApplicationCredentials(
+        configuration.getApplicationKey(), configuration.getApplicationSecret());
   }
 
   private void setApplicationCredentials(String key, String secret) {
@@ -89,8 +91,7 @@ public class VerificationService implements com.sinch.sdk.domains.verification.V
     checkCredentials();
     if (null == this.webhooks) {
       this.webhooks =
-          new com.sinch.sdk.domains.verification.adapters.WebHooksService(
-              webhooksAuthManagers);
+          new com.sinch.sdk.domains.verification.adapters.WebHooksService(webhooksAuthManagers);
     }
     return this.webhooks;
   }

--- a/client/src/main/com/sinch/sdk/domains/verification/adapters/VerificationsService.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/adapters/VerificationsService.java
@@ -22,14 +22,10 @@ public class VerificationsService
   private final SendingAndReportingVerificationsApi api;
 
   public VerificationsService(
-      Configuration configuration,
-      HttpClient httpClient,
-      Map<String, AuthManager> authManagers) {
-    this.api = new SendingAndReportingVerificationsApi(
-        httpClient,
-        configuration.getVerificationServer(),
-        authManagers,
-        new HttpMapper());
+      Configuration configuration, HttpClient httpClient, Map<String, AuthManager> authManagers) {
+    this.api =
+        new SendingAndReportingVerificationsApi(
+            httpClient, configuration.getVerificationServer(), authManagers, new HttpMapper());
   }
 
   protected SendingAndReportingVerificationsApi getApi() {

--- a/client/src/main/com/sinch/sdk/domains/verification/adapters/WebHooksService.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/adapters/WebHooksService.java
@@ -37,13 +37,18 @@ public class WebHooksService implements com.sinch.sdk.domains.verification.WebHo
     String authorizationKeyword = split.length > 0 ? split[0] : "";
     String authorizationHash = split.length > 1 ? split[1] : "";
 
-    String computedHash = computeHash(caseInsensitiveHeaders, authorizationKeyword, method, path, jsonPayload);
+    String computedHash =
+        computeHash(caseInsensitiveHeaders, authorizationKeyword, method, path, jsonPayload);
 
     return computedHash.equals(authorizationHash);
   }
 
-  private String computeHash(Map<String, String> caseInsensitiveHeaders, String authorizationKeyword,
-      String method, String path, String jsonPayload) {
+  private String computeHash(
+      Map<String, String> caseInsensitiveHeaders,
+      String authorizationKeyword,
+      String method,
+      String path,
+      String jsonPayload) {
     // getting content type header
     String contentTypeHeader = caseInsensitiveHeaders.getOrDefault("content-type", "");
 

--- a/client/src/main/com/sinch/sdk/domains/verification/adapters/converters/VerificationsDtoConverter.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/adapters/converters/VerificationsDtoConverter.java
@@ -205,12 +205,11 @@ public class VerificationsDtoConverter {
     switch (dto.getMethod()) {
       case FLASHCALL:
         {
-          VerificationReportFlashCall.Builder abuilder =
-              VerificationReportFlashCall.builder();
+          VerificationReportFlashCall.Builder abuilder = VerificationReportFlashCall.builder();
 
-              if (null != dto.getSource()) {
-                abuilder.setSource(VerificationSourceType.from(dto.getSource()));
-              }
+          if (null != dto.getSource()) {
+            abuilder.setSource(VerificationSourceType.from(dto.getSource()));
+          }
           if (null != dto.getPrice()
               && null != dto.getPrice().getVerificationPriceInformationDto()) {
             VerificationPriceInformationDto price =
@@ -226,8 +225,7 @@ public class VerificationsDtoConverter {
         }
       case SMS:
         {
-          VerificationReportSMS.Builder abuilder =
-              VerificationReportSMS.builder();
+          VerificationReportSMS.Builder abuilder = VerificationReportSMS.builder();
           if (null != dto.getSource()) {
             abuilder.setSource(VerificationSourceType.from(dto.getSource()));
           }

--- a/client/src/main/com/sinch/sdk/domains/verification/models/LinkRelType.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/models/LinkRelType.java
@@ -14,6 +14,7 @@ public class LinkRelType extends EnumDynamic<String, LinkRelType> {
 
   /** Get the status of a Verification. */
   public static final LinkRelType STATUS = new LinkRelType("status");
+
   /** Report a verification */
   public static final LinkRelType REPORT = new LinkRelType("report");
 

--- a/client/src/main/com/sinch/sdk/domains/verification/models/NumberIdentity.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/models/NumberIdentity.java
@@ -9,7 +9,9 @@ public class NumberIdentity extends Identity {
     return endpoint;
   }
 
-  /** @param endpoint An E.164-compatible phone number. */
+  /**
+   * @param endpoint An E.164-compatible phone number.
+   */
   public NumberIdentity(String endpoint) {
     super("number");
     this.endpoint = endpoint;

--- a/client/src/main/com/sinch/sdk/domains/verification/models/VerificationMethodType.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/models/VerificationMethodType.java
@@ -14,16 +14,19 @@ public class VerificationMethodType extends EnumDynamic<String, VerificationMeth
 
   /** Verification by SMS message with a PIN code */
   public static final VerificationMethodType SMS = new VerificationMethodType("sms");
+
   /**
    * Verification by placing a flashcall (missed call) and detecting the incoming calling number
    * (CLI).
    */
   public static final VerificationMethodType FLASH_CALL = new VerificationMethodType("flashcall");
+
   /**
    * Verification by placing a PSTN call to the user's phone and playing an announcement, asking the
    * user to press a particular digit to verify the phone number.
    */
   public static final VerificationMethodType CALLOUT = new VerificationMethodType("callout");
+
   /**
    * Data verification. Verification by accessing internal infrastructure of mobile carriers to
    * verify if given verification attempt was originated from device with matching phone number.

--- a/client/src/main/com/sinch/sdk/domains/verification/models/VerificationReportCallout.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/models/VerificationReportCallout.java
@@ -6,6 +6,7 @@ public class VerificationReportCallout extends VerificationReport {
   private final Price terminationPrice;
   private final Integer billableDuration;
   private final Boolean callComplete;
+
   /**
    * @param id The unique ID of the verification request
    * @param status The status of the verification request

--- a/client/src/main/com/sinch/sdk/domains/verification/models/VerificationReportFlashCall.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/models/VerificationReportFlashCall.java
@@ -6,6 +6,7 @@ public class VerificationReportFlashCall extends VerificationReport {
   private final Price terminationPrice;
   private final Integer billableDuration;
   private final VerificationSourceType source;
+
   /**
    * @param id The unique ID of the verification request
    * @param status The status of the verification request

--- a/client/src/main/com/sinch/sdk/domains/verification/models/VerificationReportSMS.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/models/VerificationReportSMS.java
@@ -4,6 +4,7 @@ public class VerificationReportSMS extends VerificationReport {
 
   private final Price verificationPrice;
   private final VerificationSourceType source;
+
   /**
    * @param id The unique ID of the verification request
    * @param status The status of the verification request

--- a/client/src/main/com/sinch/sdk/domains/verification/models/VerificationReportStatusType.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/models/VerificationReportStatusType.java
@@ -16,17 +16,22 @@ public class VerificationReportStatusType
   /** The verification is ongoing */
   public static final VerificationReportStatusType PENDING =
       new VerificationReportStatusType("PENDING");
+
   /** The verification was successful */
   public static final VerificationReportStatusType SUCCESSFUL =
       new VerificationReportStatusType("SUCCESSFUL");
+
   /** The verification attempt was made, but the number wasn't verified */
   public static final VerificationReportStatusType FAIL = new VerificationReportStatusType("FAIL");
+
   /** The verification attempt was denied by Sinch or your backend */
   public static final VerificationReportStatusType DENIED =
       new VerificationReportStatusType("DENIED");
+
   /** The verification attempt was aborted by requesting a new verification */
   public static final VerificationReportStatusType ABORTED =
       new VerificationReportStatusType("ABORTED");
+
   /**
    * The verification couldn't be completed due to a network error or the number being unreachable
    */

--- a/client/src/main/com/sinch/sdk/domains/verification/models/VerificationSourceType.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/models/VerificationSourceType.java
@@ -12,10 +12,10 @@ import java.util.stream.Stream;
  */
 public class VerificationSourceType extends EnumDynamic<String, VerificationSourceType> {
 
-  public static final VerificationSourceType INTERCEPTED = new VerificationSourceType("intercepted");
+  public static final VerificationSourceType INTERCEPTED =
+      new VerificationSourceType("intercepted");
 
   public static final VerificationSourceType MANUAL = new VerificationSourceType("manual");
-
 
   /** */
   private static final EnumSupportDynamic<String, VerificationSourceType> ENUM_SUPPORT =

--- a/client/src/main/com/sinch/sdk/domains/verification/models/webhooks/VerificationEvent.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/models/webhooks/VerificationEvent.java
@@ -31,13 +31,16 @@ public class VerificationEvent {
 
   /**
    * Base class for verification event
+   *
    * @param id The ID of the verification request.
    * @param event The type of the event.
    * @param method The verification method
-   * @param identity Specifies the type of endpoint that will be verified and the particular endpoint. number is currently the only supported endpoint type
-   * @param reference The reference ID that was optionally passed together with the verification request
-   * @param custom A custom string that can be provided during a verification request.
-   * see <a href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/">https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/</a>
+   * @param identity Specifies the type of endpoint that will be verified and the particular
+   *     endpoint. number is currently the only supported endpoint type
+   * @param reference The reference ID that was optionally passed together with the verification
+   *     request
+   * @param custom A custom string that can be provided during a verification request. see <a
+   *     href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/">https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/</a>
    * @since 1.0
    */
   @JsonCreator

--- a/client/src/main/com/sinch/sdk/domains/verification/models/webhooks/VerificationRequestEvent.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/models/webhooks/VerificationRequestEvent.java
@@ -12,18 +12,28 @@ public class VerificationRequestEvent extends VerificationEvent {
   private final Collection<String> acceptLanguage;
 
   /**
-   *This event is a POST request to the specified verification callback URL and is triggered when a new verification request is made from the SDK client or the Verification Request API. This callback event is only triggered when a verification callback URL is specified in your dashboard.
+   * This event is a POST request to the specified verification callback URL and is triggered when a
+   * new verification request is made from the SDK client or the Verification Request API. This
+   * callback event is only triggered when a verification callback URL is specified in your
+   * dashboard.
+   *
    * @param id The ID of the verification request.
    * @param event The type of the event.
    * @param method The verification method
-   * @param identity Specifies the type of endpoint that will be verified and the particular endpoint. number is currently the only supported endpoint type
-   * @param reference The reference ID that was optionally passed together with the verification request
+   * @param identity Specifies the type of endpoint that will be verified and the particular
+   *     endpoint. number is currently the only supported endpoint type
+   * @param reference The reference ID that was optionally passed together with the verification
+   *     request
    * @param custom A custom string that can be provided during a verification request.
    * @param price The amount of money and currency of the verification request
-   * @param acceptLanguage Allows you to set or override if provided in the API request, the SMS verification content language. Only used with the SMS verification method. The content language specified in the API request or in the callback can be overridden by carrier provider specific templates, due to compliance and legal requirements, such as US shortcode requirements
-   * see <a href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationRequestEvent/post">https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationRequestEvent/post</a>
+   * @param acceptLanguage Allows you to set or override if provided in the API request, the SMS
+   *     verification content language. Only used with the SMS verification method. The content
+   *     language specified in the API request or in the callback can be overridden by carrier
+   *     provider specific templates, due to compliance and legal requirements, such as US shortcode
+   *     requirements see <a
+   *     href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationRequestEvent/post">https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationRequestEvent/post</a>
    * @since 1.0
-       */
+   */
   @JsonCreator
   VerificationRequestEvent(
       @JsonProperty("id") String id,

--- a/client/src/main/com/sinch/sdk/domains/verification/models/webhooks/VerificationResponse.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/models/webhooks/VerificationResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Base class for verification callback response
+ *
  * @since 1.0
  */
 public class VerificationResponse {
@@ -12,7 +13,6 @@ public class VerificationResponse {
   private final VerificationResponseActionType action;
 
   /**
-   *
    * @param action Determines whether the verification can be executed
    */
   VerificationResponse(VerificationResponseActionType action) {

--- a/client/src/main/com/sinch/sdk/domains/verification/models/webhooks/VerificationResponseActionType.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/models/webhooks/VerificationResponseActionType.java
@@ -7,8 +7,10 @@ import java.util.Arrays;
 import java.util.stream.Stream;
 
 /**
- * Determines whether the verification can be executed.
- * See <a href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationRequestEvent/post!c=200&amp;path=0/action&amp;t=response">action type response documentation</a>
+ * Determines whether the verification can be executed. See <a
+ * href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationRequestEvent/post!c=200&amp;path=0/action&amp;t=response">action
+ * type response documentation</a>
+ *
  * @since 1.0
  */
 public class VerificationResponseActionType

--- a/client/src/main/com/sinch/sdk/domains/verification/models/webhooks/VerificationResponseCallout.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/models/webhooks/VerificationResponseCallout.java
@@ -2,16 +2,13 @@ package com.sinch.sdk.domains.verification.models.webhooks;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/**
- * Verification response related to call out
- */
+/** Verification response related to call out */
 public class VerificationResponseCallout extends VerificationResponse {
 
   @JsonProperty("callout")
   private final CalloutResponse callout;
 
   /**
-   *
    * @param action Determines whether the verification can be executed.
    * @param callout call out related information
    */
@@ -30,8 +27,10 @@ public class VerificationResponseCallout extends VerificationResponse {
   }
 
   /**
-   * Call out related information for call out verification callback
-   * See <a href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationRequestEvent/post!c=200&amp;path=2/callout&amp;t=response">callout response documentation</a>
+   * Call out related information for call out verification callback See <a
+   * href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationRequestEvent/post!c=200&amp;path=2/callout&amp;t=response">callout
+   * response documentation</a>
+   *
    * @since 1.0
    */
   public static class CalloutResponse {
@@ -43,8 +42,9 @@ public class VerificationResponseCallout extends VerificationResponse {
     private final SpeechResponse speech;
 
     /**
-     *
-     * @param code The Phone Call PIN that should be entered by the user. Sinch servers automatically generate PIN codes for Phone Call verification. If you want to set your own code, you can specify it in the response to the Verification Request Event.
+     * @param code The Phone Call PIN that should be entered by the user. Sinch servers
+     *     automatically generate PIN codes for Phone Call verification. If you want to set your own
+     *     code, you can specify it in the response to the Verification Request Event.
      * @param speech An object defining various properties for the text-to-speech message.
      */
     public CalloutResponse(Integer code, SpeechResponse speech) {
@@ -67,8 +67,10 @@ public class VerificationResponseCallout extends VerificationResponse {
   }
 
   /**
-   * Speech related information for SMS verification callback
-   * See <a href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationRequestEvent/post!c=200&amp;path=2/callout&amp;t=response">speech response documentation</a>
+   * Speech related information for SMS verification callback See <a
+   * href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationRequestEvent/post!c=200&amp;path=2/callout&amp;t=response">speech
+   * response documentation</a>
+   *
    * @since 1.0
    */
   public static class SpeechResponse {
@@ -77,8 +79,8 @@ public class VerificationResponseCallout extends VerificationResponse {
     private final String locale;
 
     /**
-     *
-     * @param locale Indicates the language that should be used for the text-to-speech message. Currently, only en-US is supported.
+     * @param locale Indicates the language that should be used for the text-to-speech message.
+     *     Currently, only en-US is supported.
      */
     public SpeechResponse(String locale) {
       this.locale = locale;

--- a/client/src/main/com/sinch/sdk/domains/verification/models/webhooks/VerificationResponseFlashCall.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/models/webhooks/VerificationResponseFlashCall.java
@@ -2,16 +2,13 @@ package com.sinch.sdk.domains.verification.models.webhooks;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/**
- * Verification response related to flash call
- */
+/** Verification response related to flash call */
 public class VerificationResponseFlashCall extends VerificationResponse {
 
   @JsonProperty("flashcall")
   private final FlashCallResponse flashCall;
 
   /**
-   *
    * @param action Determines whether the verification can be executed.
    * @param flashCall Flash call related information
    */
@@ -31,8 +28,10 @@ public class VerificationResponseFlashCall extends VerificationResponse {
   }
 
   /**
-   * Flash call related information for flach call verification callback
-   * See <a href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationRequestEvent/post!c=200&amp;path=1/flashCall&amp;t=response">callout response documentation</a>
+   * Flash call related information for flach call verification callback See <a
+   * href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationRequestEvent/post!c=200&amp;path=1/flashCall&amp;t=response">callout
+   * response documentation</a>
+   *
    * @since 1.0
    */
   public static class FlashCallResponse {
@@ -44,9 +43,15 @@ public class VerificationResponseFlashCall extends VerificationResponse {
     private final Integer dialTimeout;
 
     /**
-     *
-      * @param cli The phone number that will be displayed to the user when the flashcall is received on the user's phone. By default, the Sinch dashboard will randomly select the CLI that will be displayed during a flashcall from a pool of numbers. If you want to set your own CLI, you can specify it in the response to the Verification Request Event.
-     * @param dialTimeout The maximum time that a flashcall verification will be active and can be completed. If the phone number hasn't been verified successfully during this time, then the verification request will fail. By default, the Sinch dashboard will automatically optimize dial time out during a flashcall. If you want to set your own dial time out for the flashcall, you can specify it in the response to the Verification Request Event.
+     * @param cli The phone number that will be displayed to the user when the flashcall is received
+     *     on the user's phone. By default, the Sinch dashboard will randomly select the CLI that
+     *     will be displayed during a flashcall from a pool of numbers. If you want to set your own
+     *     CLI, you can specify it in the response to the Verification Request Event.
+     * @param dialTimeout The maximum time that a flashcall verification will be active and can be
+     *     completed. If the phone number hasn't been verified successfully during this time, then
+     *     the verification request will fail. By default, the Sinch dashboard will automatically
+     *     optimize dial time out during a flashcall. If you want to set your own dial time out for
+     *     the flashcall, you can specify it in the response to the Verification Request Event.
      */
     public FlashCallResponse(String cli, Integer dialTimeout) {
       this.cli = cli;

--- a/client/src/main/com/sinch/sdk/domains/verification/models/webhooks/VerificationResponseSMS.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/models/webhooks/VerificationResponseSMS.java
@@ -3,17 +3,14 @@ package com.sinch.sdk.domains.verification.models.webhooks;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Collection;
 
-/**
- * Verification response related to SMS
- */
+/** Verification response related to SMS */
 public class VerificationResponseSMS extends VerificationResponse {
 
   @JsonProperty("sms")
   private final SMSResponse sms;
 
   /**
-   *
-    * @param action Determines whether the verification can be executed.
+   * @param action Determines whether the verification can be executed.
    * @param sms SMS related information
    */
   VerificationResponseSMS(VerificationResponseActionType action, SMSResponse sms) {
@@ -31,8 +28,10 @@ public class VerificationResponseSMS extends VerificationResponse {
   }
 
   /**
-   * SMS related information for SMS verification callback
-   * See <a href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationRequestEvent/post!c=200&amp;path=0/action&amp;t=response">sms response documentation</a>
+   * SMS related information for SMS verification callback See <a
+   * href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationRequestEvent/post!c=200&amp;path=0/action&amp;t=response">sms
+   * response documentation</a>
+   *
    * @since 1.0
    */
   public static class SMSResponse {
@@ -43,8 +42,9 @@ public class VerificationResponseSMS extends VerificationResponse {
     private final Collection<String> acceptLanguage;
 
     /**
-     *
-     * @param code The SMS PIN that should be used. By default, the Sinch dashboard will automatically generate PIN codes for SMS verification. If you want to set your own PIN, you can specify it in the response to the Verification Request Event.
+     * @param code The SMS PIN that should be used. By default, the Sinch dashboard will
+     *     automatically generate PIN codes for SMS verification. If you want to set your own PIN,
+     *     you can specify it in the response to the Verification Request Event.
      * @param acceptLanguage The SMS verification content language. Set in the verification request.
      */
     public SMSResponse(Integer code, Collection<String> acceptLanguage) {

--- a/client/src/main/com/sinch/sdk/domains/verification/models/webhooks/VerificationResultEvent.java
+++ b/client/src/main/com/sinch/sdk/domains/verification/models/webhooks/VerificationResultEvent.java
@@ -14,18 +14,25 @@ public class VerificationResultEvent extends VerificationEvent {
   private final VerificationSourceType source;
 
   /**
-   * This event is a POST request to the specified verification callback URL and triggered when a verification has been completed and the result is known. It's used to report the verification result to the developer's backend application. This callback event is only triggered when the verification callback URL is specified in your dashboard.
+   * This event is a POST request to the specified verification callback URL and triggered when a
+   * verification has been completed and the result is known. It's used to report the verification
+   * result to the developer's backend application. This callback event is only triggered when the
+   * verification callback URL is specified in your dashboard.
+   *
    * @param id The ID of the verification request.
    * @param event The type of the event.
    * @param method The verification method
-   * @param identity Specifies the type of endpoint that will be verified and the particular endpoint. number is currently the only supported endpoint type
-   * @param reference The reference ID that was optionally passed together with the verification request
+   * @param identity Specifies the type of endpoint that will be verified and the particular
+   *     endpoint. number is currently the only supported endpoint type
+   * @param reference The reference ID that was optionally passed together with the verification
+   *     request
    * @param custom A custom string that can be provided during a verification request.
    * @param status The status of the verification request
    * @param reason Displays the reason why a verification has FAILED, was DENIED, or was ABORTED
-   * @param source Free text that the client is sending, used to show if the call/SMS was intercepted or not.
-   *     see <a href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationResultEvent/post">https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationResultEvent/post</a>
-   *       @since 1.0
+   * @param source Free text that the client is sending, used to show if the call/SMS was
+   *     intercepted or not. see <a
+   *     href="https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationResultEvent/post">https://developers.sinch.com/docs/verification/api-reference/verification/tag/Verification-callbacks/#tag/Verification-callbacks/paths/VerificationResultEvent/post</a>
+   * @since 1.0
    */
   @JsonCreator
   VerificationResultEvent(

--- a/client/src/main/com/sinch/sdk/models/Configuration.java
+++ b/client/src/main/com/sinch/sdk/models/Configuration.java
@@ -2,9 +2,7 @@ package com.sinch.sdk.models;
 
 import com.sinch.sdk.core.models.ServerConfiguration;
 
-/**
- * Configuration used by Sinch Client
- */
+/** Configuration used by Sinch Client */
 public class Configuration {
 
   private final String keyId;
@@ -17,7 +15,6 @@ public class Configuration {
   private final String verificationUrl;
   private final String applicationKey;
   private final String applicationSecret;
-
 
   private Configuration(
       String keyId,
@@ -155,7 +152,7 @@ public class Configuration {
    *
    * @return SMS region
    * @see <a
-   * href="https://developers.sinch.com/docs/sms/api-reference/#base-url/">https://developers.sinch.com/docs/sms/api-reference/#base-url/</a>
+   *     href="https://developers.sinch.com/docs/sms/api-reference/#base-url/">https://developers.sinch.com/docs/sms/api-reference/#base-url/</a>
    * @since 1.0
    */
   public SMSRegion getSmsRegion() {
@@ -194,14 +191,14 @@ public class Configuration {
 
   /**
    * Application key to be used for Verification and Voice services
-   * <p>
-   * Use application secret in place of unified configuration for authentication (see Sinch
+   *
+   * <p>Use application secret in place of unified configuration for authentication (see Sinch
    * dashboard for details) These credentials are related to Verification &amp; Voice Apps
    *
    * @return Application key
    * @see <a
-   * href="https://developers.sinch.com/docs/verification/api-reference/authentication/">Sinch
-   * Documentation</a>
+   *     href="https://developers.sinch.com/docs/verification/api-reference/authentication/">Sinch
+   *     Documentation</a>
    * @since 1.0
    */
   public String getApplicationKey() {
@@ -210,14 +207,14 @@ public class Configuration {
 
   /**
    * Application secret to be used for Verification and Voice services
-   * <p>
-   * Use application secret in place of unified configuration for authentication (see Sinch
+   *
+   * <p>Use application secret in place of unified configuration for authentication (see Sinch
    * dashboard for details) These credentials are related to Verification &amp; Voice Apps
    *
    * @return Application key
    * @see <a
-   * href="https://developers.sinch.com/docs/verification/api-reference/authentication/">Sinch
-   * Documentation</a>
+   *     href="https://developers.sinch.com/docs/verification/api-reference/authentication/">Sinch
+   *     Documentation</a>
    * @since 1.0
    */
   public String getApplicationSecret() {
@@ -232,9 +229,7 @@ public class Configuration {
     return new Builder(configuration);
   }
 
-  /**
-   * Configuration builder
-   */
+  /** Configuration builder */
   public static class Builder {
 
     private String keyId;
@@ -248,8 +243,7 @@ public class Configuration {
     private String applicationKey;
     private String applicationSecret;
 
-    protected Builder() {
-    }
+    protected Builder() {}
 
     /**
      * Initialize a builder with existing configuration
@@ -278,8 +272,16 @@ public class Configuration {
      */
     public Configuration build() {
       return new Configuration(
-          keyId, keySecret, projectId, oauthUrl, numbersUrl, smsRegion, smsUrl, verificationUrl,
-          applicationKey, applicationSecret);
+          keyId,
+          keySecret,
+          projectId,
+          oauthUrl,
+          numbersUrl,
+          smsRegion,
+          smsUrl,
+          verificationUrl,
+          applicationKey,
+          applicationSecret);
     }
 
     /**

--- a/client/src/main/com/sinch/sdk/models/SMSRegion.java
+++ b/client/src/main/com/sinch/sdk/models/SMSRegion.java
@@ -21,10 +21,13 @@ public class SMSRegion extends EnumDynamic<String, SMSRegion> {
 
   /** European Union */
   public static final SMSRegion EU = new SMSRegion("eu");
+
   /** Australia */
   public static final SMSRegion AU = new SMSRegion("au");
+
   /** Brazil */
   public static final SMSRegion BR = new SMSRegion("br");
+
   /** Canada */
   public static final SMSRegion CA = new SMSRegion("ca");
 

--- a/client/src/test/java/com/sinch/sdk/domains/verification/adapters/WebhooksServiceTest.java
+++ b/client/src/test/java/com/sinch/sdk/domains/verification/adapters/WebhooksServiceTest.java
@@ -46,7 +46,9 @@ public class WebhooksServiceTest extends BaseTest {
 
     Map<String, String> headers =
         Stream.of(
-                new AbstractMap.SimpleEntry<>("authorization", "application badkey:xfKhO0XvlRNJraahUBEJzzi1f3Fn3pYO41/ZzwOHPaQ="),
+                new AbstractMap.SimpleEntry<>(
+                    "authorization",
+                    "application badkey:xfKhO0XvlRNJraahUBEJzzi1f3Fn3pYO41/ZzwOHPaQ="),
                 new AbstractMap.SimpleEntry<>("content-type", "application/json; charset=utf-8"),
                 new AbstractMap.SimpleEntry<>("x-timestamp", "2023-12-01T15:01:20.0406449Z"))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
@@ -56,6 +58,7 @@ public class WebhooksServiceTest extends BaseTest {
 
     Assertions.assertThat(authenticationResult).isEqualTo(false);
   }
+
   @Test
   void checkApplicationAuthenticationFailureOnHash() throws ApiException {
 
@@ -75,13 +78,14 @@ public class WebhooksServiceTest extends BaseTest {
   @BeforeEach
   public void setUp() throws IOException {
 
-    Configuration configuration = Configuration.builder()
-        .setProjectId("unused")
-        .setKeyId("unused")
-        .setKeySecret("unused")
-        .setApplicationKey("789")
-        .setApplicationSecret("9876543210")
-        .build();
+    Configuration configuration =
+        Configuration.builder()
+            .setProjectId("unused")
+            .setKeyId("unused")
+            .setKeySecret("unused")
+            .setApplicationKey("789")
+            .setApplicationSecret("9876543210")
+            .build();
 
     webHooksService = new SinchClient(configuration).verification().webhooks();
   }

--- a/core/src/main/com/sinch/sdk/core/http/JavaTimeFormatter.java
+++ b/core/src/main/com/sinch/sdk/core/http/JavaTimeFormatter.java
@@ -44,6 +44,7 @@ public class JavaTimeFormatter {
       throw new RuntimeException(e);
     }
   }
+
   /**
    * Format the given {@code OffsetDateTime} object into string.
    *

--- a/core/src/main/com/sinch/sdk/core/models/ServerConfiguration.java
+++ b/core/src/main/com/sinch/sdk/core/models/ServerConfiguration.java
@@ -5,7 +5,9 @@ public class ServerConfiguration {
 
   public final String url;
 
-  /** @param url A URL to the target host. */
+  /**
+   * @param url A URL to the target host.
+   */
   public ServerConfiguration(String url) {
     this.url = url;
   }

--- a/core/src/main/com/sinch/sdk/core/utils/databind/JSONNavigator.java
+++ b/core/src/main/com/sinch/sdk/core/utils/databind/JSONNavigator.java
@@ -12,6 +12,7 @@ public class JSONNavigator {
   /** A map of discriminators for all model classes. */
   private static final Map<Class<?>, ClassDiscriminatorMapping> modelDiscriminators =
       new HashMap<>();
+
   /** A map of oneOf/anyOf descendants for each model class. */
   private static final Map<Class<?>, Map<String, Class<?>>> modelDescendants = new HashMap<>();
 

--- a/openapi-contracts/src/main/com/sinch/sdk/domains/numbers/adapters/api/v1/ActiveNumberApi.java
+++ b/openapi-contracts/src/main/com/sinch/sdk/domains/numbers/adapters/api/v1/ActiveNumberApi.java
@@ -142,6 +142,7 @@ public class ActiveNumberApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * List active numbers Lists all virtual numbers for a project.
    *
@@ -338,6 +339,7 @@ public class ActiveNumberApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Release number With this endpoint, you can cancel your subscription for a specific virtual
    * phone number.
@@ -425,6 +427,7 @@ public class ActiveNumberApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Update active number Update a virtual phone number. For example: you can configure SMS/Voice
    * services or set a friendly name. To update the name that displays, modify the

--- a/openapi-contracts/src/main/com/sinch/sdk/domains/numbers/adapters/api/v1/AvailableNumberApi.java
+++ b/openapi-contracts/src/main/com/sinch/sdk/domains/numbers/adapters/api/v1/AvailableNumberApi.java
@@ -149,6 +149,7 @@ public class AvailableNumberApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * List available numbers Search for virtual numbers that are available for you to activate. You
    * can filter by any property on the available number resource.
@@ -326,6 +327,7 @@ public class AvailableNumberApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Rent any number that matches the criteria Search for and activate an available Sinch virtual
    * number all in one API call. Currently the rentAny operation works only for US 10DLC numbers
@@ -410,6 +412,7 @@ public class AvailableNumberApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Rent an available number Activate a virtual number to use with SMS products, Voice products, or
    * both. You&#39;ll use &#x60;smsConfiguration&#x60; to setup your number for SMS and

--- a/openapi-contracts/src/main/com/sinch/sdk/domains/numbers/adapters/api/v1/CallbackConfigurationApi.java
+++ b/openapi-contracts/src/main/com/sinch/sdk/domains/numbers/adapters/api/v1/CallbackConfigurationApi.java
@@ -120,6 +120,7 @@ public class CallbackConfigurationApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Update callback configuration Updates the callbacks configuration for the specified project
    *

--- a/openapi-contracts/src/main/com/sinch/sdk/domains/numbers/models/dto/v1/ListAvailableRegionsResponseDto.java
+++ b/openapi-contracts/src/main/com/sinch/sdk/domains/numbers/models/dto/v1/ListAvailableRegionsResponseDto.java
@@ -43,7 +43,9 @@ public class ListAvailableRegionsResponseDto {
     return this;
   }
 
-  /** @return availableRegions */
+  /**
+   * @return availableRegions
+   */
   @JsonProperty(JSON_PROPERTY_AVAILABLE_REGIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public List<AvailableRegionDto> getAvailableRegions() {

--- a/openapi-contracts/src/main/com/sinch/sdk/domains/sms/adapters/api/v1/BatchesApi.java
+++ b/openapi-contracts/src/main/com/sinch/sdk/domains/sms/adapters/api/v1/BatchesApi.java
@@ -140,6 +140,7 @@ public class BatchesApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Send delivery feedback for a message Send feedback if your system can confirm successful
    * message delivery. Feedback can only be provided if &#x60;feedback_enabled&#x60; was set when
@@ -239,6 +240,7 @@ public class BatchesApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Dry run This operation will perform a dry run of a batch which calculates the bodies and number
    * of parts for all messages in the batch without actually sending any messages.
@@ -348,6 +350,7 @@ public class BatchesApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Get a batch message This operation returns a specific batch that matches the provided batch ID.
    *
@@ -424,6 +427,7 @@ public class BatchesApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * List Batches With the list operation you can list batch messages created in the last 14 days
    * that you have created. This operation supports pagination.
@@ -570,6 +574,7 @@ public class BatchesApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Replace a batch This operation will replace all the parameters of a batch with the provided
    * values. It is the same as cancelling a batch and sending a new one instead.
@@ -658,6 +663,7 @@ public class BatchesApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Send Send a message or a batch of messages. Depending on the length of the body, one message
    * might be split into multiple parts and charged accordingly. Any groups targeted in a scheduled
@@ -737,6 +743,7 @@ public class BatchesApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Update a Batch message This operation updates all specified parameters of a batch that matches
    * the provided batch ID.

--- a/openapi-contracts/src/main/com/sinch/sdk/domains/sms/adapters/api/v1/DeliveryReportsApi.java
+++ b/openapi-contracts/src/main/com/sinch/sdk/domains/sms/adapters/api/v1/DeliveryReportsApi.java
@@ -172,6 +172,7 @@ public class DeliveryReportsApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Retrieve a recipient delivery report A recipient delivery report contains the message status
    * for a single recipient phone number.
@@ -272,6 +273,7 @@ public class DeliveryReportsApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Retrieve a list of delivery reports Get a list of finished delivery reports. This operation
    * supports pagination.

--- a/openapi-contracts/src/main/com/sinch/sdk/domains/sms/adapters/api/v1/GroupsApi.java
+++ b/openapi-contracts/src/main/com/sinch/sdk/domains/sms/adapters/api/v1/GroupsApi.java
@@ -134,6 +134,7 @@ public class GroupsApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Delete a group This operation deletes the group with the provided group ID.
    *
@@ -206,6 +207,7 @@ public class GroupsApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Get phone numbers for a group This operation retrieves the members of the group with the
    * provided group ID.
@@ -281,6 +283,7 @@ public class GroupsApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * List Groups With the list operation you can list all groups that you have created. This
    * operation supports pagination. Groups are returned in reverse chronological order.
@@ -368,6 +371,7 @@ public class GroupsApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Replace a group The replace operation will replace all parameters, including members, of an
    * existing group with new values. Replacing a group targeted by a batch message scheduled in the
@@ -458,6 +462,7 @@ public class GroupsApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Retrieve a group This operation retrieves a specific group with the provided group ID.
    *
@@ -534,6 +539,7 @@ public class GroupsApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Update a group With the update group operation, you can add and remove members in an existing
    * group as well as rename the group. This method encompasses a few ways to update a group: 1. By

--- a/openapi-contracts/src/main/com/sinch/sdk/domains/sms/adapters/api/v1/InboundsApi.java
+++ b/openapi-contracts/src/main/com/sinch/sdk/domains/sms/adapters/api/v1/InboundsApi.java
@@ -211,6 +211,7 @@ public class InboundsApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Retrieve inbound message This operation retrieves a specific inbound message with the provided
    * inbound ID.

--- a/openapi-contracts/src/main/com/sinch/sdk/domains/verification/adapters/api/v1/QueryVerificationsApi.java
+++ b/openapi-contracts/src/main/com/sinch/sdk/domains/verification/adapters/api/v1/QueryVerificationsApi.java
@@ -117,6 +117,7 @@ public class QueryVerificationsApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Get verification by Identity Queries the verification result by sending the verification
    * Identity and its method. With this query you can get the result of a verification.
@@ -208,6 +209,7 @@ public class QueryVerificationsApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Get verification by Reference Queries the verification result by sending the verification
    * Reference. With this query you can get the result of a verification.

--- a/openapi-contracts/src/main/com/sinch/sdk/domains/verification/adapters/api/v1/SendingAndReportingVerificationsApi.java
+++ b/openapi-contracts/src/main/com/sinch/sdk/domains/verification/adapters/api/v1/SendingAndReportingVerificationsApi.java
@@ -140,6 +140,7 @@ public class SendingAndReportingVerificationsApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Verify verification code by Identity Used to report OTP code.
    *
@@ -239,6 +240,7 @@ public class SendingAndReportingVerificationsApi {
         localVarContentTypes,
         localVarAuthNames);
   }
+
   /**
    * Start verification This method is used by the mobile and web Verification SDKs to start a
    * verification. It can also be used to request a verification from your backend, by making an

--- a/pom.xml
+++ b/pom.xml
@@ -270,13 +270,20 @@
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
                 <version>2.40.0</version>
+
                 <configuration>
+                    <json>
+                        <includes>
+                            <include>**/*.json</include>
+                        </includes>
+                    </json>
                     <java>
                         <includes>
                             <include>**/*.java</include>
                         </includes>
                       <excludes>
-                        <exclude>**/*.java</exclude>
+                          <!-- java 21 style not yet supported -->
+                        <exclude>sample-app/src/main/java/com/sinch/sample/webhooks/verification/VerificationController.java</exclude>
                       </excludes>
                         <googleJavaFormat>
                             <version>1.18.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <httpclient5.version>5.2.1</httpclient5.version>
 
         <!-- tests -->
-        <mockito.version>5.5.0</mockito.version>
+        <mockito.version>5.8.0</mockito.version>
         <maven.failsafe.plugin.version>3.2.1</maven.failsafe.plugin.version>
         <maven-surefire-plugin.version>3.2.1</maven-surefire-plugin.version>
 
@@ -279,7 +279,7 @@
                         <exclude>**/*.java</exclude>
                       </excludes>
                         <googleJavaFormat>
-                            <version>1.8</version>
+                            <version>1.18.1</version>
                             <style>GOOGLE</style>
                             <reflowLongStrings>true</reflowLongStrings>
                         </googleJavaFormat>
@@ -356,6 +356,13 @@
             <groupId>io.hosuaby</groupId>
             <artifactId>inject-resources-core</artifactId>
             <version>0.3.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.14.10</version>
             <scope>test</scope>
         </dependency>
 

--- a/sample-app/src/main/java/com/sinch/sample/BaseApplication.java
+++ b/sample-app/src/main/java/com/sinch/sample/BaseApplication.java
@@ -34,7 +34,6 @@ public abstract class BaseApplication {
             : properties.getProperty(BATCH_ID_KEY);
 
     client = new SinchClient(configuration);
-
   }
 
   public abstract void run();

--- a/sample-app/src/main/java/com/sinch/sample/Utils.java
+++ b/sample-app/src/main/java/com/sinch/sample/Utils.java
@@ -80,5 +80,4 @@ public class Utils {
         .setApplicationSecret(verificationApiSecret)
         .build();
   }
-
 }

--- a/sample-app/src/main/java/com/sinch/sample/verification/verifications/Start.java
+++ b/sample-app/src/main/java/com/sinch/sample/verification/verifications/Start.java
@@ -12,8 +12,7 @@ public class Start extends BaseApplication {
 
   private static final Logger LOGGER = Logger.getLogger(Start.class.getName());
 
-  public Start() throws IOException {
-  }
+  public Start() throws IOException {}
 
   public static void main(String[] args) {
     try {

--- a/sample-app/src/main/java/com/sinch/sample/webhooks/VerificationApplication.java
+++ b/sample-app/src/main/java/com/sinch/sample/webhooks/VerificationApplication.java
@@ -3,7 +3,6 @@ package com.sinch.sample.webhooks;
 import com.sinch.sample.Utils;
 import com.sinch.sdk.SinchClient;
 import com.sinch.sdk.models.Configuration;
-import java.util.Properties;
 import java.util.logging.Logger;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -21,6 +20,6 @@ public class VerificationApplication {
   @Bean
   public SinchClient sinchClient() {
     Configuration configuration = Utils.loadConfiguration(LOGGER);
-   return new SinchClient(configuration);
+    return new SinchClient(configuration);
   }
 }


### PR DESCRIPTION
- Bump mockito version: JDK 21 can be used for SDK compilation (generated SDK is still Java 8 compliant)
- Bump google java format version: apply style to sources

No new feature: only sources style & build