### PR TITLE
ci: Add GitHub action for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,9 @@
     </developers>
 
     <scm>
-        <url>https://github.com/sinch/sinch-sdk-java/tree/main</url>
-        <connection>scm:git:git://github.com/sinch/sinch-sdk-java.git</connection>
-        <developerConnection>scm:git:ssh://github.com:sinch/sinch-sdk-java.git</developerConnection>
+        <url>https://github.com/sinch/sinch-sdk-java.git</url>
+        <connection>scm:git:${project.scm.url}</connection>
+        <developerConnection>scm:git:${project.scm.url}</developerConnection>
     </scm>
 
     <issueManagement>
@@ -76,7 +76,7 @@
         <!-- releasing -->
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.6.0</maven.javadoc.plugin.version>
-        <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+        <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
         <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
         <nexus-staging-maven-plugin>1.6.13</nexus-staging-maven-plugin>
     </properties>
@@ -261,10 +261,14 @@
             <!-- deployment/releasing-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>${maven-deploy-plugin.version}</version>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven-release-plugin.version}</version>
                 <configuration>
-                    <skip>true</skip>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release</releaseProfiles>
+                    <tagNameFormat>@{project.version}</tagNameFormat>
+                    <goals>deploy</goals>
                 </configuration>
             </plugin>
 
@@ -414,7 +418,14 @@
 
     <profiles>
         <profile>
-            <id>deploy</id>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+
             <build>
                 <plugins>
 
@@ -450,7 +461,7 @@
                                 </goals>
                                 <configuration>
                                     <keyname>${gpg.keyname}</keyname>
-                                    <passphraseServerId>${gpg.keyname}</passphraseServerId>
+                                    <passphraseServerId>${gpg.passphrase}</passphraseServerId>
                                     <gpgArguments>
                                         <arg>--pinentry-mode</arg>
                                         <arg>loopback</arg>
@@ -465,15 +476,6 @@
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <version>${nexus-staging-maven-plugin}</version>
                         <extensions>true</extensions>
-                        <executions>
-                            <execution>
-                                <id>default-deploy</id>
-                                <phase>deploy</phase>
-                                <goals>
-                                    <goal>deploy</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                         <configuration>
                             <!-- Source: https://help.sonatype.com/repomanager2/staging-releases/configuring-your-project-for-deployment
                                serverId: The id of the server element in settings.xml from which the user credentials for accessing the repository manager should be retrieved

--- a/settings.xml
+++ b/settings.xml
@@ -13,7 +13,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <gpg.keyname>${env.GPG_KEY}</gpg.keyname>
+                <gpg.keyname>${env.GPG_KEY_ID}</gpg.keyname>
                 <gpg.passphrase>${env.GPG_PWD}</gpg.passphrase>
             </properties>
         </profile>


### PR DESCRIPTION
Adding a github action to release Java SDK
Usage after PR merged:
- got to https://github.com/sinch/sinch-sdk-java/actions and select `Tag & Release`
- (or direct access  https://github.com/sinch/sinch-sdk-java/actions/workflows/release.yaml)
- Select "Run workflow" button
- Fill required fields for version to be released (will be also used to create a tag) and next dev version (to update pom.xml)
- According to values the action will:
  - create tag
  - commit pom.xml according to version and next version
  - create and sign artifacts
  - push artifacts to staging maven repository
So to finalize a release; operator will finish the release by:
- checking artifacts
- push staging to release maven repository
- create a release note

Demo with this PR:
- release.yaml file from main branch (to be able to trigger it from github UI): https://github.com/sinch/sinch-sdk-java/blob/main/.github/workflows/release.yaml
- action execution: https://github.com/sinch/sinch-sdk-java/actions/runs/7265315276
- tag `v1.2.3` created: https://github.com/sinch/sinch-sdk-java/tags
- 2 commits (see below PR's commit list)
  - `[release] Set release & tag: 1.2.3`
  - `[release] Set next version: 1.2.4-SNAPSHOT`
- maven repository staging to be validated: https://oss.sonatype.org/#stagingRepositories (comsinch-1133)

📓 :  tag and commits will have to removed before merge and staging repository to be deleted without pushing it as a true release