### PR TITLE
refactor: Align SDK function from OAS to SDK naming

### DIFF
--- a/client/src/main/com/sinch/sdk/domains/voice/ApplicationsService.java
+++ b/client/src/main/com/sinch/sdk/domains/voice/ApplicationsService.java
@@ -2,7 +2,7 @@ package com.sinch.sdk.domains.voice;
 
 import com.sinch.sdk.domains.voice.models.CallbackUrls;
 import com.sinch.sdk.domains.voice.models.NumberInformation;
-import com.sinch.sdk.domains.voice.models.requests.ApplicationsUpdateNumbersRequestParameters;
+import com.sinch.sdk.domains.voice.models.requests.ApplicationsAssignNumbersRequestParameters;
 import com.sinch.sdk.domains.voice.models.response.AssignedNumbers;
 import com.sinch.sdk.models.E164PhoneNumber;
 
@@ -42,7 +42,7 @@ public interface ApplicationsService {
    * @param parameters Request parameters
    * @since 1.0
    */
-  void updateNumbers(ApplicationsUpdateNumbersRequestParameters parameters);
+  void assignNumbers(ApplicationsAssignNumbersRequestParameters parameters);
 
   /**
    * Un-assign a number from an application.

--- a/client/src/main/com/sinch/sdk/domains/voice/adapters/ApplicationsService.java
+++ b/client/src/main/com/sinch/sdk/domains/voice/adapters/ApplicationsService.java
@@ -7,7 +7,7 @@ import com.sinch.sdk.domains.voice.adapters.api.v1.ApplicationsApi;
 import com.sinch.sdk.domains.voice.adapters.converters.ApplicationsDtoConverter;
 import com.sinch.sdk.domains.voice.models.CallbackUrls;
 import com.sinch.sdk.domains.voice.models.NumberInformation;
-import com.sinch.sdk.domains.voice.models.requests.ApplicationsUpdateNumbersRequestParameters;
+import com.sinch.sdk.domains.voice.models.requests.ApplicationsAssignNumbersRequestParameters;
 import com.sinch.sdk.domains.voice.models.response.AssignedNumbers;
 import com.sinch.sdk.models.Configuration;
 import com.sinch.sdk.models.E164PhoneNumber;
@@ -51,7 +51,7 @@ public class ApplicationsService implements com.sinch.sdk.domains.voice.Applicat
     return ApplicationsDtoConverter.convert(getApi().callingQueryNumber(number.stringValue()));
   }
 
-  public void updateNumbers(ApplicationsUpdateNumbersRequestParameters parameters) {
+  public void assignNumbers(ApplicationsAssignNumbersRequestParameters parameters) {
     getApi().configurationUpdateNumbers(ApplicationsDtoConverter.convert(parameters));
   }
 

--- a/client/src/main/com/sinch/sdk/domains/voice/adapters/converters/ApplicationsDtoConverter.java
+++ b/client/src/main/com/sinch/sdk/domains/voice/adapters/converters/ApplicationsDtoConverter.java
@@ -13,7 +13,7 @@ import com.sinch.sdk.domains.voice.models.dto.v1.GetQueryNumberDto;
 import com.sinch.sdk.domains.voice.models.dto.v1.GetQueryNumberNumberDto;
 import com.sinch.sdk.domains.voice.models.dto.v1.UnassignNumbersDto;
 import com.sinch.sdk.domains.voice.models.dto.v1.UpdateNumbersDto;
-import com.sinch.sdk.domains.voice.models.requests.ApplicationsUpdateNumbersRequestParameters;
+import com.sinch.sdk.domains.voice.models.requests.ApplicationsAssignNumbersRequestParameters;
 import com.sinch.sdk.domains.voice.models.response.AssignedNumbers;
 import com.sinch.sdk.models.E164PhoneNumber;
 import java.util.List;
@@ -69,7 +69,7 @@ public class ApplicationsDtoConverter {
         .build();
   }
 
-  public static UpdateNumbersDto convert(ApplicationsUpdateNumbersRequestParameters client) {
+  public static UpdateNumbersDto convert(ApplicationsAssignNumbersRequestParameters client) {
     if (null == client) {
       return null;
     }

--- a/client/src/main/com/sinch/sdk/domains/voice/models/requests/ApplicationsAssignNumbersRequestParameters.java
+++ b/client/src/main/com/sinch/sdk/domains/voice/models/requests/ApplicationsAssignNumbersRequestParameters.java
@@ -10,13 +10,13 @@ import java.util.Collection;
  *
  * @since 1.0
  */
-public class ApplicationsUpdateNumbersRequestParameters {
+public class ApplicationsAssignNumbersRequestParameters {
 
   private final OptionalValue<Collection<E164PhoneNumber>> numbers;
   private final OptionalValue<String> applicationKey;
   private final OptionalValue<CapabilityType> capability;
 
-  private ApplicationsUpdateNumbersRequestParameters(
+  private ApplicationsAssignNumbersRequestParameters(
       OptionalValue<Collection<E164PhoneNumber>> numbers,
       OptionalValue<String> applicationKey,
       OptionalValue<CapabilityType> capability) {
@@ -60,7 +60,7 @@ public class ApplicationsUpdateNumbersRequestParameters {
 
   @Override
   public String toString() {
-    return "ApplicationsUpdateNumbersRequestParameters{"
+    return "ApplicationsAssignNumbersRequestParameters{"
         + "numbers="
         + numbers
         + ", applicationKey='"
@@ -126,8 +126,8 @@ public class ApplicationsUpdateNumbersRequestParameters {
       return this;
     }
 
-    public ApplicationsUpdateNumbersRequestParameters build() {
-      return new ApplicationsUpdateNumbersRequestParameters(numbers, applicationKey, capability);
+    public ApplicationsAssignNumbersRequestParameters build() {
+      return new ApplicationsAssignNumbersRequestParameters(numbers, applicationKey, capability);
     }
   }
 }

--- a/client/src/test/java/com/sinch/sdk/domains/voice/adapters/ApplicationsServiceTest.java
+++ b/client/src/test/java/com/sinch/sdk/domains/voice/adapters/ApplicationsServiceTest.java
@@ -99,8 +99,8 @@ public class ApplicationsServiceTest extends BaseTest {
 
   @Test
   void updateNumbers() {
-    service.updateNumbers(
-        ApplicationsDtoConverterTest.expectedApplicationsUpdateNumbersRequestParameters);
+    service.assignNumbers(
+        ApplicationsDtoConverterTest.expectedApplicationsAssignNumbersRequestParameters);
 
     verify(api).configurationUpdateNumbers(updateNumbersDtoCaptor.capture());
 
@@ -108,7 +108,7 @@ public class ApplicationsServiceTest extends BaseTest {
     Assertions.assertThat(body)
         .isEqualTo(
             ApplicationsDtoConverter.convert(
-                ApplicationsDtoConverterTest.expectedApplicationsUpdateNumbersRequestParameters));
+                ApplicationsDtoConverterTest.expectedApplicationsAssignNumbersRequestParameters));
   }
 
   @Test

--- a/client/src/test/java/com/sinch/sdk/domains/voice/adapters/converters/ApplicationsDtoConverterTest.java
+++ b/client/src/test/java/com/sinch/sdk/domains/voice/adapters/converters/ApplicationsDtoConverterTest.java
@@ -14,7 +14,7 @@ import com.sinch.sdk.domains.voice.models.dto.v1.ApplicationsGetNumbersResponseD
 import com.sinch.sdk.domains.voice.models.dto.v1.ApplicationsQueryNumberResponseDtoTest;
 import com.sinch.sdk.domains.voice.models.dto.v1.ApplicationsUnassignNumberRequestDtoTest;
 import com.sinch.sdk.domains.voice.models.dto.v1.ApplicationsUpdateNumberRequestDtoTest;
-import com.sinch.sdk.domains.voice.models.requests.ApplicationsUpdateNumbersRequestParameters;
+import com.sinch.sdk.domains.voice.models.requests.ApplicationsAssignNumbersRequestParameters;
 import com.sinch.sdk.domains.voice.models.response.AssignedNumbers;
 import com.sinch.sdk.models.E164PhoneNumber;
 import java.util.Arrays;
@@ -58,9 +58,9 @@ public class ApplicationsDtoConverterTest extends BaseTest {
           .setRate(Price.builder().setCurrencyId("USD").setAmount(0.1850F).build())
           .build();
 
-  public static ApplicationsUpdateNumbersRequestParameters
-      expectedApplicationsUpdateNumbersRequestParameters =
-          ApplicationsUpdateNumbersRequestParameters.builder()
+  public static ApplicationsAssignNumbersRequestParameters
+      expectedApplicationsAssignNumbersRequestParameters =
+          ApplicationsAssignNumbersRequestParameters.builder()
               .setNumbers(Collections.singletonList(E164PhoneNumber.valueOf("+12073091712")))
               .setApplicationKey("an app key")
               .setCapability(CapabilityType.VOICE)
@@ -100,7 +100,7 @@ public class ApplicationsDtoConverterTest extends BaseTest {
   @Test
   void convertApplicationsUpdateNumberRequestParameters() {
     Assertions.assertThat(
-            ApplicationsDtoConverter.convert(expectedApplicationsUpdateNumbersRequestParameters))
+            ApplicationsDtoConverter.convert(expectedApplicationsAssignNumbersRequestParameters))
         .usingRecursiveComparison()
         .isEqualTo(ApplicationsUpdateNumberRequestDtoTest.updateNumbersDto);
   }

--- a/sample-app/README.md
+++ b/sample-app/README.md
@@ -141,7 +141,7 @@ See https://developers.sinch.com for details about these parameters
 |              | QueryNumber        | [com.sinch.sample.voice.applications.QueryNumber](src/main/java/com/sinch/sample/voice/applications/QueryNumber.java)               | Require `PHONE_NUMBER` parameter                          | 
 |              | UnassignNumber     | [com.sinch.sample.voice.applications.UnassignNumber](src/main/java/com/sinch/sample/voice/applications/UnassignNumber.java)         | Require `APPLICATION_API_KEY` & `PHONE_NUMBER` parameters | 
 |              | UpdateCallbackUrls | [com.sinch.sample.voice.applications.UpdateCallbackUrls](src/main/java/com/sinch/sample/voice/applications/UpdateCallbackUrls.java) | Require `APPLICATION_API_KEY` parameter                   | 
-|              | UpdateNumbers      | [com.sinch.sample.voice.applications.UpdateNumbers](src/main/java/com/sinch/sample/voice/applications/UpdateNumbers.java)           | Require `APPLICATION_API_KEY` & `PHONE_NUMBER` parameters | 
+|              | AssignNumbers      | [com.sinch.sample.voice.applications.AssignNumbers](src/main/java/com/sinch/sample/voice/applications/AssignNumbers.java)           | Require `APPLICATION_API_KEY` & `PHONE_NUMBER` parameters | 
 
 ### Dedicated webhooks feature samples
 #### How to run webhooks sample application

--- a/sample-app/src/main/java/com/sinch/sample/voice/applications/AssignNumbers.java
+++ b/sample-app/src/main/java/com/sinch/sample/voice/applications/AssignNumbers.java
@@ -2,21 +2,21 @@ package com.sinch.sample.voice.applications;
 
 import com.sinch.sample.BaseApplication;
 import com.sinch.sdk.domains.voice.models.CapabilityType;
-import com.sinch.sdk.domains.voice.models.requests.ApplicationsUpdateNumbersRequestParameters;
+import com.sinch.sdk.domains.voice.models.requests.ApplicationsAssignNumbersRequestParameters;
 import com.sinch.sdk.models.E164PhoneNumber;
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Logger;
 
-public class UpdateNumbers extends BaseApplication {
+public class AssignNumbers extends BaseApplication {
 
-  private static final Logger LOGGER = Logger.getLogger(UpdateNumbers.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(AssignNumbers.class.getName());
 
-  public UpdateNumbers() throws IOException {}
+  public AssignNumbers() throws IOException {}
 
   public static void main(String[] args) {
     try {
-      new UpdateNumbers().run();
+      new AssignNumbers().run();
     } catch (Exception e) {
       LOGGER.severe(e.getMessage());
       e.printStackTrace();
@@ -30,8 +30,8 @@ public class UpdateNumbers extends BaseApplication {
     client
         .voice()
         .applications()
-        .updateNumbers(
-            ApplicationsUpdateNumbersRequestParameters.builder()
+        .assignNumbers(
+            ApplicationsAssignNumbersRequestParameters.builder()
                 .setNumbers(List.of(E164PhoneNumber.valueOf(phoneNumber)))
                 .setApplicationKey(applicationKey)
                 .setCapability(CapabilityType.VOICE)


### PR DESCRIPTION
- Aligned SDK function from OAS to SDK naming : `voice.updateNumbers()` to `voice.assignNumbers()` 
- DTO resources tests files (within openapi-contracts) are not impacted: naming is still related to OAS