### PR TITLE
style: Upgrade google code format to 1.22 (supporting java 21 style)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -316,14 +316,9 @@
                         <includes>
                             <include>**/*.java</include>
                         </includes>
-                      <excludes>
-                        <!-- java 21 style not yet supported -->
-                        <exclude>sample-app/src/main/java/com/sinch/sample/webhooks/sms/SmsController.java</exclude>
-                        <exclude>sample-app/src/main/java/com/sinch/sample/webhooks/verification/VerificationController.java</exclude>
-                        <exclude>sample-app/src/main/java/com/sinch/sample/webhooks/voice/VoiceController.java</exclude>
-                      </excludes>
+
                         <googleJavaFormat>
-                            <version>1.18.1</version>
+                            <version>1.22.0</version>
                             <style>GOOGLE</style>
                             <reflowLongStrings>true</reflowLongStrings>
                         </googleJavaFormat>

--- a/sample-app/src/main/java/com/sinch/sample/webhooks/sms/SmsController.java
+++ b/sample-app/src/main/java/com/sinch/sample/webhooks/sms/SmsController.java
@@ -49,5 +49,4 @@ public class SmsController {
       default -> throw new IllegalStateException("Unexpected value: " + event);
     }
   }
-
 }

--- a/sample-app/src/main/java/com/sinch/sample/webhooks/voice/VoiceController.java
+++ b/sample-app/src/main/java/com/sinch/sample/webhooks/voice/VoiceController.java
@@ -34,8 +34,7 @@ public class VoiceController {
       value = "/VoiceEvent",
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
-  public String VoiceEvent(
-      @RequestHeader Map<String, String> headers, @RequestBody String body) {
+  public String VoiceEvent(@RequestHeader Map<String, String> headers, @RequestBody String body) {
 
     LOGGER.finest("Received body:" + body);
     LOGGER.finest("Received headers: " + headers);


### PR DESCRIPTION
- Upgrade Java SDK version used from CI to Java 21 (artifacts are still Java 8 compliant)
- Upgrade google code format to 1.22 (supporting java 21 style)