### PR TITLE
fixes (Verification): Fixes for OptionalValue getter and DelegatedSerialize

### DIFF
--- a/openapi-contracts/src/main/com/sinch/sdk/domains/verification/models/v1/report/request/VerificationReportRequestFlashCallImpl.java
+++ b/openapi-contracts/src/main/com/sinch/sdk/domains/verification/models/v1/report/request/VerificationReportRequestFlashCallImpl.java
@@ -5,10 +5,19 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.sinch.sdk.core.models.OptionalValue;
 import com.sinch.sdk.domains.verification.models.v1.report.request.internal.VerificationReportRequestFlashCallOptions;
+import com.sinch.sdk.domains.verification.models.v1.report.request.internal.VerificationReportRequestFlashCallOptionsImpl;
+import java.io.IOException;
 import java.util.Objects;
+import java.util.Optional;
 
 @JsonPropertyOrder({
   VerificationReportRequestFlashCallImpl.JSON_PROPERTY_METHOD,
@@ -69,8 +78,10 @@ public class VerificationReportRequestFlashCallImpl
   }
 
   public OptionalValue<String> cli() {
-    return null != flashCall
-        ? flashCall.map(VerificationReportRequestFlashCallOptions::getCli)
+    return null != flashCall && flashCall.isPresent()
+        ? flashCall
+            .map(f -> ((VerificationReportRequestFlashCallOptionsImpl) f).cli())
+            .orElse(OptionalValue.empty())
         : OptionalValue.empty();
   }
 
@@ -147,5 +158,46 @@ public class VerificationReportRequestFlashCallImpl
       }
       return new VerificationReportRequestFlashCallImpl(method, flashCall);
     }
+  }
+
+  public static class DelegatedSerializer
+      extends JsonSerializer<OptionalValue<VerificationReportRequestFlashCall>> {
+    @Override
+    public void serialize(
+        OptionalValue<VerificationReportRequestFlashCall> value,
+        JsonGenerator jgen,
+        SerializerProvider provider)
+        throws IOException {
+
+      if (!value.isPresent()) {
+        return;
+      }
+      VerificationReportRequestFlashCallImpl impl =
+          (VerificationReportRequestFlashCallImpl) value.get();
+      jgen.writeObject(null != impl ? impl.getFlashCall() : null);
+    }
+  }
+
+  public static class DelegatedDeSerializer
+      extends JsonDeserializer<VerificationReportRequestFlashCall> {
+    @Override
+    public VerificationReportRequestFlashCall deserialize(
+        JsonParser jp, DeserializationContext ctxt) throws IOException {
+
+      VerificationReportRequestFlashCallImpl.Builder builder =
+          new VerificationReportRequestFlashCallImpl.Builder();
+      VerificationReportRequestFlashCallOptionsImpl deserialized =
+          jp.readValueAs(VerificationReportRequestFlashCallOptionsImpl.class);
+      builder.setFlashCall(deserialized);
+      return builder.build();
+    }
+  }
+
+  public static Optional<VerificationReportRequestFlashCall> delegatedConverter(
+      VerificationReportRequestFlashCallOptions internal) {
+    if (null == internal) {
+      return Optional.empty();
+    }
+    return Optional.of(new Builder().setFlashCall(internal).build());
   }
 }

--- a/openapi-contracts/src/main/com/sinch/sdk/domains/verification/models/v1/start/request/VerificationStartRequestSmsImpl.java
+++ b/openapi-contracts/src/main/com/sinch/sdk/domains/verification/models/v1/start/request/VerificationStartRequestSmsImpl.java
@@ -5,13 +5,21 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.sinch.sdk.core.models.OptionalValue;
 import com.sinch.sdk.domains.verification.models.v1.Identity;
 import com.sinch.sdk.domains.verification.models.v1.VerificationMethod;
 import com.sinch.sdk.domains.verification.models.v1.start.request.internal.VerificationStartSmsOptions;
 import com.sinch.sdk.domains.verification.models.v1.start.request.internal.VerificationStartSmsOptionsImpl;
+import java.io.IOException;
 import java.util.Objects;
+import java.util.Optional;
 
 @JsonPropertyOrder({
   VerificationStartRequestSmsImpl.JSON_PROPERTY_IDENTITY,
@@ -126,8 +134,10 @@ public class VerificationStartRequestSmsImpl
   }
 
   public OptionalValue<String> expiry() {
-    return null != smsOptions
-        ? smsOptions.map(VerificationStartSmsOptions::getExpiry)
+    return null != smsOptions && smsOptions.isPresent()
+        ? smsOptions
+            .map(f -> ((VerificationStartSmsOptionsImpl) f).expiry())
+            .orElse(OptionalValue.empty())
         : OptionalValue.empty();
   }
 
@@ -140,7 +150,7 @@ public class VerificationStartRequestSmsImpl
   }
 
   public OptionalValue<CodeTypeEnum> codeType() {
-    return null != smsOptions
+    return null != smsOptions && smsOptions.isPresent()
         ? smsOptions.map(f -> CodeTypeEnum.from(smsOptions.get().getCodeType().value()))
         : OptionalValue.empty();
   }
@@ -154,8 +164,10 @@ public class VerificationStartRequestSmsImpl
   }
 
   public OptionalValue<String> template() {
-    return null != smsOptions
-        ? smsOptions.map(VerificationStartSmsOptions::getTemplate)
+    return null != smsOptions && smsOptions.isPresent()
+        ? smsOptions
+            .map(f -> ((VerificationStartSmsOptionsImpl) f).template())
+            .orElse(OptionalValue.empty())
         : OptionalValue.empty();
   }
 
@@ -170,8 +182,10 @@ public class VerificationStartRequestSmsImpl
   }
 
   public OptionalValue<String> acceptLanguage() {
-    return null != smsOptions
-        ? smsOptions.map(VerificationStartSmsOptions::getAcceptLanguage)
+    return null != smsOptions && smsOptions.isPresent()
+        ? smsOptions
+            .map(f -> ((VerificationStartSmsOptionsImpl) f).acceptLanguage())
+            .orElse(OptionalValue.empty())
         : OptionalValue.empty();
   }
 
@@ -297,5 +311,44 @@ public class VerificationStartRequestSmsImpl
       }
       return new VerificationStartRequestSmsImpl(identity, method, reference, custom, smsOptions);
     }
+  }
+
+  public static class DelegatedSerializer
+      extends JsonSerializer<OptionalValue<VerificationStartRequestSms>> {
+    @Override
+    public void serialize(
+        OptionalValue<VerificationStartRequestSms> value,
+        JsonGenerator jgen,
+        SerializerProvider provider)
+        throws IOException {
+
+      if (!value.isPresent()) {
+        return;
+      }
+      VerificationStartRequestSmsImpl impl = (VerificationStartRequestSmsImpl) value.get();
+      jgen.writeObject(null != impl ? impl.getSmsOptions() : null);
+    }
+  }
+
+  public static class DelegatedDeSerializer extends JsonDeserializer<VerificationStartRequestSms> {
+    @Override
+    public VerificationStartRequestSms deserialize(JsonParser jp, DeserializationContext ctxt)
+        throws IOException {
+
+      VerificationStartRequestSmsImpl.Builder builder =
+          new VerificationStartRequestSmsImpl.Builder();
+      VerificationStartSmsOptionsImpl deserialized =
+          jp.readValueAs(VerificationStartSmsOptionsImpl.class);
+      builder.setSmsOptions(deserialized);
+      return builder.build();
+    }
+  }
+
+  public static Optional<VerificationStartRequestSms> delegatedConverter(
+      VerificationStartSmsOptions internal) {
+    if (null == internal) {
+      return Optional.empty();
+    }
+    return Optional.of(new Builder().setSmsOptions(internal).build());
   }
 }

--- a/openapi-contracts/src/main/com/sinch/sdk/domains/verification/models/v1/start/response/VerificationStartResponseFlashCallImpl.java
+++ b/openapi-contracts/src/main/com/sinch/sdk/domains/verification/models/v1/start/response/VerificationStartResponseFlashCallImpl.java
@@ -5,12 +5,21 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.sinch.sdk.core.models.OptionalValue;
 import com.sinch.sdk.domains.verification.models.v1.VerificationMethod;
 import com.sinch.sdk.domains.verification.models.v1.start.response.internal.VerificationStartResponseFlashCallContent;
+import com.sinch.sdk.domains.verification.models.v1.start.response.internal.VerificationStartResponseFlashCallContentImpl;
+import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 @JsonPropertyOrder({
   VerificationStartResponseFlashCallImpl.JSON_PROPERTY_ID,
@@ -107,8 +116,10 @@ public class VerificationStartResponseFlashCallImpl
   }
 
   public OptionalValue<String> cliFilter() {
-    return null != flashCall
-        ? flashCall.map(VerificationStartResponseFlashCallContent::getCliFilter)
+    return null != flashCall && flashCall.isPresent()
+        ? flashCall
+            .map(f -> ((VerificationStartResponseFlashCallContentImpl) f).cliFilter())
+            .orElse(OptionalValue.empty())
         : OptionalValue.empty();
   }
 
@@ -123,8 +134,10 @@ public class VerificationStartResponseFlashCallImpl
   }
 
   public OptionalValue<Integer> interceptionTimeout() {
-    return null != flashCall
-        ? flashCall.map(VerificationStartResponseFlashCallContent::getInterceptionTimeout)
+    return null != flashCall && flashCall.isPresent()
+        ? flashCall
+            .map(f -> ((VerificationStartResponseFlashCallContentImpl) f).interceptionTimeout())
+            .orElse(OptionalValue.empty())
         : OptionalValue.empty();
   }
 
@@ -137,8 +150,10 @@ public class VerificationStartResponseFlashCallImpl
   }
 
   public OptionalValue<Integer> reportTimeout() {
-    return null != flashCall
-        ? flashCall.map(VerificationStartResponseFlashCallContent::getReportTimeout)
+    return null != flashCall && flashCall.isPresent()
+        ? flashCall
+            .map(f -> ((VerificationStartResponseFlashCallContentImpl) f).reportTimeout())
+            .orElse(OptionalValue.empty())
         : OptionalValue.empty();
   }
 
@@ -151,8 +166,10 @@ public class VerificationStartResponseFlashCallImpl
   }
 
   public OptionalValue<Integer> denyCallAfter() {
-    return null != flashCall
-        ? flashCall.map(VerificationStartResponseFlashCallContent::getDenyCallAfter)
+    return null != flashCall && flashCall.isPresent()
+        ? flashCall
+            .map(f -> ((VerificationStartResponseFlashCallContentImpl) f).denyCallAfter())
+            .orElse(OptionalValue.empty())
         : OptionalValue.empty();
   }
 
@@ -265,5 +282,46 @@ public class VerificationStartResponseFlashCallImpl
       }
       return new VerificationStartResponseFlashCallImpl(id, method, links, flashCall);
     }
+  }
+
+  public static class DelegatedSerializer
+      extends JsonSerializer<OptionalValue<VerificationStartResponseFlashCall>> {
+    @Override
+    public void serialize(
+        OptionalValue<VerificationStartResponseFlashCall> value,
+        JsonGenerator jgen,
+        SerializerProvider provider)
+        throws IOException {
+
+      if (!value.isPresent()) {
+        return;
+      }
+      VerificationStartResponseFlashCallImpl impl =
+          (VerificationStartResponseFlashCallImpl) value.get();
+      jgen.writeObject(null != impl ? impl.getFlashCall() : null);
+    }
+  }
+
+  public static class DelegatedDeSerializer
+      extends JsonDeserializer<VerificationStartResponseFlashCall> {
+    @Override
+    public VerificationStartResponseFlashCall deserialize(
+        JsonParser jp, DeserializationContext ctxt) throws IOException {
+
+      VerificationStartResponseFlashCallImpl.Builder builder =
+          new VerificationStartResponseFlashCallImpl.Builder();
+      VerificationStartResponseFlashCallContentImpl deserialized =
+          jp.readValueAs(VerificationStartResponseFlashCallContentImpl.class);
+      builder.setFlashCall(deserialized);
+      return builder.build();
+    }
+  }
+
+  public static Optional<VerificationStartResponseFlashCall> delegatedConverter(
+      VerificationStartResponseFlashCallContent internal) {
+    if (null == internal) {
+      return Optional.empty();
+    }
+    return Optional.of(new Builder().setFlashCall(internal).build());
   }
 }


### PR DESCRIPTION
- fix: OptionalValue getter for delegated fields wrongly returned OptionalValue.of(null) value instead of OptionalValue.empty() when delegated field was empty
- fix: Guard against null for DelegatedSerializer