### PR TITLE
DEVEXP-536: Fix UTF-8 encoding for body payloads (#121)

### DIFF
--- a/core/src/main/com/sinch/sdk/core/http/HttpContentType.java
+++ b/core/src/main/com/sinch/sdk/core/http/HttpContentType.java
@@ -1,12 +1,18 @@
 package com.sinch.sdk.core.http;
 
+import com.sinch.sdk.core.utils.StringUtil;
 import java.util.Collection;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class HttpContentType {
 
   public static final String CONTENT_TYPE_HEADER = "content-type";
   public static final String APPLICATION_JSON = "application/json";
   public static final String TEXT_PLAIN = "text/plain";
+
+  static Pattern charsetPattern = Pattern.compile("(.*;$)?\\s*?charset=\\s*([^;\\s]+)");
 
   public static boolean isMimeJson(Collection<String> mimes) {
     String jsonMime = "(?i)^(" + APPLICATION_JSON + "|[^;/ \t]+/[^;/ \t]+[+]json)[ \t]*(;.*)?$";
@@ -16,5 +22,17 @@ public class HttpContentType {
 
   public static boolean isMimeTextPlain(Collection<String> mimes) {
     return mimes.stream().anyMatch(TEXT_PLAIN::equalsIgnoreCase);
+  }
+
+  public static Optional<String> getCharsetValue(String contentTypeHeader) {
+    if (StringUtil.isEmpty(contentTypeHeader)) {
+      return Optional.empty();
+    }
+
+    Matcher m = charsetPattern.matcher(contentTypeHeader);
+    if (!m.find()) {
+      return Optional.empty();
+    }
+    return Optional.of(m.group(2));
   }
 }

--- a/core/src/test/java/com/sinch/sdk/core/http/HttpContentTypeTest.java
+++ b/core/src/test/java/com/sinch/sdk/core/http/HttpContentTypeTest.java
@@ -1,0 +1,69 @@
+package com.sinch.sdk.core.http;
+
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class HttpContentTypeTest {
+
+  @Test
+  void getCharsetValueDefaultEmpty() {
+    Assertions.assertThat(HttpContentType.getCharsetValue("")).isEqualTo(Optional.empty());
+  }
+
+  @Test
+  void getCharsetValueNullEmpty() {
+    Assertions.assertThat(HttpContentType.getCharsetValue(null)).isEqualTo(Optional.empty());
+  }
+
+  @Test
+  void getCharsetValueNoCharset() {
+    Assertions.assertThat(HttpContentType.getCharsetValue("text/html")).isEqualTo(Optional.empty());
+  }
+
+  @Test
+  void getCharsetValueNoCharsetWithSemiColon() {
+    Assertions.assertThat(HttpContentType.getCharsetValue("text/html;"))
+        .isEqualTo(Optional.empty());
+  }
+
+  @Test
+  void getCharsetValueStartOfString() {
+    Assertions.assertThat(HttpContentType.getCharsetValue(" charset=utf-16; text/html"))
+        .isEqualTo(Optional.of("utf-16"));
+  }
+
+  @Test
+  void getCharsetValueStartOfStringWithSemiColon() {
+    Assertions.assertThat(HttpContentType.getCharsetValue(" charset=utf-16; text/html;"))
+        .isEqualTo(Optional.of("utf-16"));
+  }
+
+  @Test
+  void getCharsetValueEndOfString() {
+    Assertions.assertThat(HttpContentType.getCharsetValue("text/html; charset=utf-16"))
+        .isEqualTo(Optional.of("utf-16"));
+  }
+
+  @Test
+  void getCharsetValueEndOfStringWithSemiColon() {
+    Assertions.assertThat(HttpContentType.getCharsetValue("text/html; charset=utf-16;"))
+        .isEqualTo(Optional.of("utf-16"));
+  }
+
+  @Test
+  void getCharsetValue() {
+    Assertions.assertThat(
+            HttpContentType.getCharsetValue(
+                "multipart/form-data; charset=utf-16; boundary=ExampleBoundaryString"))
+        .isEqualTo(Optional.of("utf-16"));
+  }
+
+  @Test
+  void getCharsetValueWithSemiColon() {
+    Assertions.assertThat(
+            HttpContentType.getCharsetValue(
+                "multipart/form-data; charset=utf-16; boundary=ExampleBoundaryString;"))
+        .isEqualTo(Optional.of("utf-16"));
+  }
+}


### PR DESCRIPTION
Report from branch 1.2 for fix: 
* fix (HttpClientApache): Defaulting to send UTF-8 encoded payload