### PR TITLE
feat (SDK/Versioning): Store SDK related informations wihtin sources

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,8 +5,8 @@ on:
       releaseVersion:
         description: "Version number to be released (use semver semantic: 'X.Y.Z')"
         required: true
-      developmentVersion:
-        description: "Next development version to be set (use semver semantic: 'X.Y.Z', `-SNAPSHOT` suffix will be automatically added)"
+      nextDevelopmentVersion:
+        description: "Next development version to be set (use semver semantic: 'X.Y.Z', `-SNAPSHOT` artifact's suffix will be automatically added)"
         required: true
 
 permissions:
@@ -58,7 +58,7 @@ jobs:
         run: scripts/release.sh
         env:
           RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
-          NEXT_VERSION: ${{ github.event.inputs.developmentVersion }}
+          NEXT_VERSION: ${{ github.event.inputs.nextDevelopmentVersion }}
           OSSRH_USER: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PWD: ${{ secrets.OSSRH_PWD }}
           GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,13 +52,13 @@ jobs:
 
       - name: Create and switch to dedicated release branch
         run: |
-          git checkout -b release-${{ github.event.inputs.releaseVersion }}
+          git checkout -b "release-${{ github.event.inputs.releaseVersion }}"
 
       - name: Release
-        run: |
-          mvn --batch-mode -s settings.xml release:clean release:prepare -Dtag=v${{ github.event.inputs.releaseVersion }} -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdevelopmentVersion=${{ github.event.inputs.developmentVersion }}-SNAPSHOT -DscmReleaseCommitComment="[release] Set release & tag: ${{ github.event.inputs.releaseVersion }}" -DscmDevelopmentCommitComment="[release] Set next version: ${{ github.event.inputs.developmentVersion }}-SNAPSHOT"
-          mvn --batch-mode -s settings.xml release:perform -Dusername=${{ env.GITHUB_USERNAME }} -Dpassword=${{ env.GITHUB_TOKEN }} -DskipTests=true
+        run: scripts/release.sh
         env:
+          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+          NEXT_VERSION: ${{ github.event.inputs.developmentVersion }}
           OSSRH_USER: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PWD: ${{ secrets.OSSRH_PWD }}
           GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
@@ -68,6 +68,7 @@ jobs:
 
 
       - name: Create dedicated release pull request
-        run: gh pr create -d -B main -H release-${{ github.event.inputs.releaseVersion }} --title "Merge release release-${{ github.event.inputs.releaseVersion }} branch into main" --body 'Created by Github action'
+        run: gh pr create -d -B main -H "release-${RELEASE_VERSION}" --title "Merge release '"release-${RELEASE_VERSION}"' branch into main" --body 'Created by Github action'
         env:
+          RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/client/resources/SDKTemplate.java
+++ b/client/resources/SDKTemplate.java
@@ -6,15 +6,18 @@ import java.util.stream.Stream;
 
 public class VersionTemplating {
 
-  public static void main(String[] args) throws IOException {
-    String versionFile = "client/src/main/com/sinch/sdk/SDK.java";
+  static final String SDK_FILE_PATH = "client/src/main/com/sinch/sdk/SDK.java";
 
-    Stream<String> lines = Files.lines(Paths.get(versionFile));
+  public static void main(String[] args) throws IOException {
+
+    String versionValue = args[0];
+
+    Stream<String> lines = Files.lines(Paths.get(SDK_FILE_PATH));
     String content = lines.collect(Collectors.joining("\n"));
     lines.close();
 
     System.out.println(
-        content.replaceAll("VERSION = \".*\"", String.format("VERSION = \"%s\"", args[0])));
+        content.replaceAll("VERSION = \".*\"", String.format("VERSION = \"%s\"", versionValue)));
     System.out.println("");
   }
 }

--- a/client/resources/SDKTemplate.java
+++ b/client/resources/SDKTemplate.java
@@ -1,0 +1,20 @@
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class VersionTemplating {
+
+  public static void main(String[] args) throws IOException {
+    String versionFile = "client/src/main/com/sinch/sdk/SDK.java";
+
+    Stream<String> lines = Files.lines(Paths.get(versionFile));
+    String content = lines.collect(Collectors.joining("\n"));
+    lines.close();
+
+    System.out.println(
+        content.replaceAll("VERSION = \".*\"", String.format("VERSION = \"%s\"", args[0])));
+    System.out.println("");
+  }
+}

--- a/client/resources/version.properties
+++ b/client/resources/version.properties
@@ -1,3 +1,0 @@
-project.version=${project.version}
-project.name=${project.name}
-project.auxiliary_flag=

--- a/client/src/main/com/sinch/sdk/SDK.java
+++ b/client/src/main/com/sinch/sdk/SDK.java
@@ -1,0 +1,8 @@
+package com.sinch.sdk;
+
+public class SDK {
+
+  public static final String NAME = "Sinch Java SDK";
+  public static final String VERSION = "1.3.0-dev";
+  public static final String AUXILIARY_FLAG = "";
+}

--- a/client/src/main/com/sinch/sdk/SinchClient.java
+++ b/client/src/main/com/sinch/sdk/SinchClient.java
@@ -27,7 +27,6 @@ import java.util.stream.Stream;
 public class SinchClient {
 
   private static final String DEFAULT_PROPERTIES_FILE_NAME = "/config-default.properties";
-  private static final String VERSION_PROPERTIES_FILE_NAME = "/version.properties";
 
   private static final String OAUTH_URL_KEY = "oauth-url";
   private static final String NUMBERS_SERVER_KEY = "numbers-server";
@@ -41,10 +40,6 @@ public class SinchClient {
 
   private static final String VERIFICATION_SERVER_KEY = "verification-server";
 
-  private static final String PROJECT_NAME_KEY = "project.name";
-  private static final String PROJECT_VERSION_KEY = "project.version";
-  private static final String PROJECT_AUXILIARY_FLAG = "project.auxiliary_flag";
-
   // sinch-sdk/{sdk_version} ({language}/{language_version}; {implementation_type};
   // {auxiliary_flag})
   private static final String SDK_USER_AGENT_HEADER = "User-Agent";
@@ -52,7 +47,6 @@ public class SinchClient {
   private static final Logger LOGGER = Logger.getLogger(SinchClient.class.getName());
 
   private final Configuration configuration;
-  private final Properties versionProperties;
 
   private NumbersService numbers;
   private SMSService sms;
@@ -85,12 +79,7 @@ public class SinchClient {
     checkConfiguration(newConfiguration);
     this.configuration = newConfiguration;
 
-    versionProperties = handlePropertiesFile(VERSION_PROPERTIES_FILE_NAME);
-    LOGGER.fine(
-        String.format(
-            "%s (%s) started",
-            versionProperties.getProperty(PROJECT_NAME_KEY),
-            versionProperties.getProperty(PROJECT_VERSION_KEY)));
+    LOGGER.fine(String.format("%s (%s) started", SDK.NAME, SDK.VERSION));
   }
 
   private void handleDefaultNumbersSettings(
@@ -320,32 +309,32 @@ public class SinchClient {
       this.httpClient = new HttpClientApache();
 
       // set SDK User-Agent
-      String userAgent = formatSdkUserAgentHeader(versionProperties);
+      String userAgent = formatSdkUserAgentHeader();
       this.httpClient.setRequestHeaders(
           Stream.of(new String[][] {{SDK_USER_AGENT_HEADER, userAgent}})
               .collect(Collectors.toMap(data -> data[0], data -> data[1])));
 
-      LOGGER.fine("HTTP client loaded");
+      LOGGER.finest(String.format("HTTP client loaded (%s='%s'", SDK_USER_AGENT_HEADER, userAgent));
     }
     return this.httpClient;
   }
 
-  private String formatSdkUserAgentHeader(Properties versionProperties) {
+  private String formatSdkUserAgentHeader() {
     return String.format(
         SDK_USER_AGENT_FORMAT,
-        versionProperties.get(PROJECT_VERSION_KEY),
+        SDK.VERSION,
         "Java",
         System.getProperty("java.version"),
         "Apache",
-        formatAuxiliaryFlag((String) versionProperties.get(PROJECT_AUXILIARY_FLAG)));
+        formatAuxiliaryFlag());
   }
 
-  private String formatAuxiliaryFlag(String auxiliaryFlag) {
+  private String formatAuxiliaryFlag() {
 
     Collection<String> values = Collections.singletonList(System.getProperty("java.vendor"));
 
-    if (!StringUtil.isEmpty(auxiliaryFlag)) {
-      values.add(auxiliaryFlag);
+    if (!StringUtil.isEmpty(SDK.AUXILIARY_FLAG)) {
+      values.add(SDK.AUXILIARY_FLAG);
     }
     return String.join(",", values);
   }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -20,14 +20,14 @@ if [ ! "${GITHUB_TOKEN}"  ]; then
   exit 1
 fi
 
-SDKFILE="client/src/main/com/sinch/sdk/SDK.java"
+SDKFILE_PATH="client/src/main/com/sinch/sdk/SDK.java"
 
 NEXT_VERSION_SNAPSHOT="${NEXT_VERSION}-SNAPSHOT"
 NEXT_VERSION_DEV="${NEXT_VERSION}-dev"
 
 # Create SDK.java file with version information
-SDK=$(java client/resources/SDKTemplate.java "$RELEASE_VERSION") && echo "$SDK" > "$SDKFILE" || exit 1
-git add "$SDKFILE" && git commit -m "build (release): Bump version to $RELEASE_VERSION for sources" || exit 1
+SDK=$(java client/resources/SDKTemplate.java "$RELEASE_VERSION") && echo "$SDK" > "$SDKFILE_PATH" || exit 1
+git add "$SDKFILE_PATH" && git commit -m "build (release): Bump version to $RELEASE_VERSION for sources" || exit 1
 
 mvn --batch-mode -s settings.xml release:clean release:prepare \
   -Dtag="v$RELEASE_VERSION" \
@@ -42,6 +42,6 @@ mvn --batch-mode -s settings.xml release:perform \
   -DskipTests=true  || exit 1
 
 # Update SDK.java file with next version information
-SDK=$(java client/resources/SDKTemplate.java "$NEXT_VERSION_DEV") && echo "$SDK" > "$SDKFILE" || exit 1
-git add "$SDKFILE" && git commit -m "build (release): Set next version to $NEXT_VERSION_DEV for sources" || exit 1
+SDK=$(java client/resources/SDKTemplate.java "$NEXT_VERSION_DEV") && echo "$SDK" > "$SDKFILE_PATH" || exit 1
+git add "$SDKFILE_PATH" && git commit -m "build (release): Set next version to $NEXT_VERSION_DEV for sources" || exit 1
 git push -u origin HEAD || exit 1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+if [ ! "${RELEASE_VERSION}"  ]; then
+  echo "Missing 'RELEASE_VERSION' env value"
+  exit 1
+fi
+
+if [ ! "${NEXT_VERSION}"  ]; then
+  echo "Missing 'NEXT_VERSION' env value"
+  exit 1
+fi
+
+if [ ! "${GITHUB_USERNAME}"  ]; then
+  echo "Missing 'GITHUB_USERNAME' env value"
+  exit 1
+fi
+
+if [ ! "${GITHUB_TOKEN}"  ]; then
+  echo "Missing 'GITHUB_TOKEN' env value"
+  exit 1
+fi
+
+SDKFILE="client/src/main/com/sinch/sdk/SDK.java"
+
+NEXT_VERSION_SNAPSHOT="${NEXT_VERSION}-SNAPSHOT"
+NEXT_VERSION_DEV="${NEXT_VERSION}-dev"
+
+# Create SDK.java file with version information
+SDK=$(java client/resources/SDKTemplate.java "$RELEASE_VERSION") && echo "$SDK" > "$SDKFILE" || exit 1
+git add "$SDKFILE" && git commit -m "build (release): Bump version to $RELEASE_VERSION for sources" || exit 1
+
+mvn --batch-mode -s settings.xml release:clean release:prepare \
+  -Dtag="v$RELEASE_VERSION" \
+  -DreleaseVersion="$RELEASE_VERSION" \
+  -DdevelopmentVersion="${NEXT_VERSION_SNAPSHOT}" \
+  -DscmReleaseCommitComment="[release] Set release & tag: $RELEASE_VERSION" \
+  -DscmDevelopmentCommitComment="[release] Set next version: ${NEXT_VERSION_SNAPSHOT}"  || exit 1
+
+mvn --batch-mode -s settings.xml release:perform \
+  -Dusername="${GITHUB_USERNAME}" \
+  -Dpassword="${GITHUB_TOKEN}" \
+  -DskipTests=true  || exit 1
+
+# Update SDK.java file with next version information
+SDK=$(java client/resources/SDKTemplate.java "$NEXT_VERSION_DEV") && echo "$SDK" > "$SDKFILE" || exit 1
+git add "$SDKFILE" && git commit -m "build (release): Set next version to $NEXT_VERSION_DEV for sources" || exit 1
+git push -u origin HEAD || exit 1


### PR DESCRIPTION
No longer using `.properties` file but store SDK related information at source level (client: [com.sinch.sdk.SDK.java](https://github.com/sinch/sinch-sdk-java/blob/DEVEXP-510-store-sdk-information-with-sources/client/src/main/com/sinch/sdk/SDK.java))
Release procedure updated to synchronize `SDK.java`file content  onto github release action

Note: the release procedure require an Java 11 runtime enabling to _execute a java source file_: The JVM compiles the source file into memory and then runs the first public main() method it finds.
Then we are using [SDKTemplate Java source](https://github.com/sinch/sinch-sdk-java/blob/DEVEXP-510-store-sdk-information-with-sources/client/resources/SDKTemplate.java) to update the `SDK.java` content, called from [release.sh script](https://github.com/sinch/sinch-sdk-java/blob/DEVEXP-510-store-sdk-information-with-sources/scripts/release.sh#L29)