### PR TITLE
DEVEXP-734: choice item media fix

### DIFF
--- a/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/ConversationService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/ConversationService.java
@@ -19,6 +19,7 @@ import com.sinch.sdk.domains.conversation.api.v1.adapters.messages.ListSectionMa
 import com.sinch.sdk.domains.conversation.api.v1.adapters.messages.OmniMessageOverrideMapper;
 import com.sinch.sdk.domains.conversation.api.v1.adapters.messages.SendMessageRequestMapper;
 import com.sinch.sdk.domains.conversation.api.v1.adapters.messages.WhatsAppInteractiveHeaderMapper;
+import com.sinch.sdk.domains.conversation.models.v1.messages.ChoiceItemMapper;
 import com.sinch.sdk.domains.conversation.models.v1.messages.internal.AppMessageInternalMapper;
 import com.sinch.sdk.domains.conversation.models.v1.messages.internal.ChannelSpecificMessageInternalMapper;
 import com.sinch.sdk.domains.conversation.models.v1.messages.internal.ContactMessageInternalMapper;
@@ -166,6 +167,7 @@ public class ConversationService
       AppMessageMapper.initMapper();
       AppMessageInternalMapper.initMapper();
       CarouselMessageMapper.initMapper();
+      ChoiceItemMapper.initMapper();
       ChannelSpecificContactMessageMapper.initMapper();
       ChannelSpecificMessageInternalMapper.initMapper();
       ChoiceMessageMapper.initMapper();

--- a/client/src/main/com/sinch/sdk/domains/conversation/models/v1/messages/ChoiceItemMapper.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/models/v1/messages/ChoiceItemMapper.java
@@ -1,0 +1,36 @@
+package com.sinch.sdk.domains.conversation.models.v1.messages;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.sinch.sdk.core.models.OptionalValue;
+import com.sinch.sdk.core.utils.databind.Mapper;
+import com.sinch.sdk.domains.conversation.models.v1.messages.types.media.MediaMessage;
+import com.sinch.sdk.domains.conversation.models.v1.messages.types.media.MediaMessageImpl;
+
+public class ChoiceItemMapper {
+
+  public static void initMapper() {
+
+    Mapper.getInstance()
+        .addMixIn(ChoiceItem.class, ChoiceItemMixinSerializer.class)
+        .addMixIn(ChoiceItem.Builder.class, ChoiceItemBuilderMapperMixin.class);
+  }
+
+  static class ChoiceItemMixinSerializer extends ChoiceItemImpl {
+
+    @Override
+    @JsonSerialize(using = MediaMessageImpl.DelegatedSerializer.class)
+    public OptionalValue<MediaMessage> media() {
+      return super.media();
+    }
+  }
+
+  static class ChoiceItemBuilderMapperMixin extends ChoiceItemImpl.Builder {
+
+    @Override
+    @JsonDeserialize(using = MediaMessageImpl.DelegatedDeSerializer.class)
+    public ChoiceItemImpl.Builder setMedia(MediaMessage media) {
+      return super.setMedia(media);
+    }
+  }
+}

--- a/openapi-contracts/src/test/resources/domains/conversation/v1/messages/AppMessageListDto.json
+++ b/openapi-contracts/src/test/resources/domains/conversation/v1/messages/AppMessageListDto.json
@@ -10,11 +10,9 @@
               "title": "choice title",
               "description": "description value",
               "media": {
-                "media_message": {
-                  "url": "an url value",
-                  "thumbnail_url": "another url",
-                  "filename_override": "filename override value"
-                }
+                "url": "an url value",
+                "thumbnail_url": "another url",
+                "filename_override": "filename override value"
               },
               "postback_data": "postback value"
             }
@@ -27,8 +25,7 @@
       "catalog_id": "catalog ID value",
       "menu": "menu value"
     }
-  }
-,
+  },
   "explicit_channel_message": {
     "KAKAOTALK": "foo value"
   },

--- a/openapi-contracts/src/test/resources/domains/conversation/v1/messages/ChoiceItemDto.json
+++ b/openapi-contracts/src/test/resources/domains/conversation/v1/messages/ChoiceItemDto.json
@@ -2,11 +2,9 @@
   "title": "choice title",
   "description": "description value",
   "media": {
-    "media_message": {
       "url": "an url value",
       "thumbnail_url": "another url",
       "filename_override": "filename override value"
-    }
   },
   "postback_data": "postback value"
 }

--- a/openapi-contracts/src/test/resources/domains/conversation/v1/messages/request/SendListMessageRequestDto.json
+++ b/openapi-contracts/src/test/resources/domains/conversation/v1/messages/request/SendListMessageRequestDto.json
@@ -15,11 +15,9 @@
                 "title": "choice title",
                 "description": "description value",
                 "media": {
-                  "media_message": {
-                    "url": "an url value",
-                    "thumbnail_url": "another url",
-                    "filename_override": "filename override value"
-                  }
+                  "url": "an url value",
+                  "thumbnail_url": "another url",
+                  "filename_override": "filename override value"
                 },
                 "postback_data": "postback value"
               }

--- a/openapi-contracts/src/test/resources/domains/conversation/v1/messages/types/list/ListMessageChoiceDto.json
+++ b/openapi-contracts/src/test/resources/domains/conversation/v1/messages/types/list/ListMessageChoiceDto.json
@@ -10,11 +10,9 @@
               "title": "choice title",
               "description": "description value",
               "media": {
-                "media_message": {
-                  "url": "an url value",
-                  "thumbnail_url": "another url",
-                  "filename_override": "filename override value"
-                }
+                "url": "an url value",
+                "thumbnail_url": "another url",
+                "filename_override": "filename override value"
               },
               "postback_data": "postback value"
             }


### PR DESCRIPTION
Fix ChoiceItem.media' field (do not contains 'media_message' depth)
Use serializer/deserializer in place managing the delegation feature
So there is no breaking change for end user: The same MediaMessage class is used used for ChoiceItem or not (e.g. ).
Not being aware about JSON payload is requiring or not different depths -> DX 😮 !