### PR TITLE
DEVEXP-736: relax credentials required for webhooks conversation

### DIFF
--- a/client/src/main/com/sinch/sdk/SinchClient.java
+++ b/client/src/main/com/sinch/sdk/SinchClient.java
@@ -374,7 +374,7 @@ public class SinchClient {
         getConfiguration().getUnifiedCredentials().orElse(null),
         getConfiguration().getConversationContext().orElse(null),
         getConfiguration().getOAuthServer(),
-        getHttpClient());
+        this::getHttpClient);
   }
 
   private Properties handlePropertiesFile(String fileName) {

--- a/client/src/main/com/sinch/sdk/SinchClient.java
+++ b/client/src/main/com/sinch/sdk/SinchClient.java
@@ -73,24 +73,38 @@ public class SinchClient {
    */
   public SinchClient(Configuration configuration) {
 
-    Configuration.Builder builder = Configuration.builder(configuration);
+    Configuration configurationGuard =
+        null != configuration ? configuration : Configuration.builder().build();
+
+    Configuration.Builder builder = Configuration.builder(configurationGuard);
     Properties props = handlePropertiesFile(DEFAULT_PROPERTIES_FILE_NAME);
 
-    if (null == configuration.getOAuthUrl() && props.containsKey(OAUTH_URL_KEY)) {
+    if (null == configurationGuard.getOAuthUrl() && props.containsKey(OAUTH_URL_KEY)) {
       builder.setOAuthUrl(props.getProperty(OAUTH_URL_KEY));
     }
 
-    handleDefaultNumbersSettings(configuration, props, builder);
-    handleDefaultSmsSettings(configuration, props, builder);
-    handleDefaultVerificationSettings(configuration, props, builder);
-    handleDefaultVoiceSettings(configuration, props, builder);
-    handleDefaultConversationSettings(configuration, props, builder);
+    handleDefaultNumbersSettings(configurationGuard, props, builder);
+    handleDefaultSmsSettings(configurationGuard, props, builder);
+    handleDefaultVerificationSettings(configurationGuard, props, builder);
+    handleDefaultVoiceSettings(configurationGuard, props, builder);
+    handleDefaultConversationSettings(configurationGuard, props, builder);
 
     Configuration newConfiguration = builder.build();
     checkConfiguration(newConfiguration);
     this.configuration = newConfiguration;
 
     LOGGER.fine(String.format("%s (%s) started", SDK.NAME, SDK.VERSION));
+  }
+
+  /**
+   * Create a Sinch Client instance without any dedicated configuration
+   *
+   * <p>Can be used to address webhooks feature not requiring credentials
+   *
+   * @since __TO_BE_DEFINED__
+   */
+  public SinchClient() {
+    this(null);
   }
 
   private void handleDefaultNumbersSettings(

--- a/client/src/main/com/sinch/sdk/domains/conversation/adapters/ConversationService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/adapters/ConversationService.java
@@ -5,13 +5,14 @@ import com.sinch.sdk.core.models.ServerConfiguration;
 import com.sinch.sdk.domains.conversation.api.templates.adapters.TemplatesService;
 import com.sinch.sdk.models.ConversationContext;
 import com.sinch.sdk.models.UnifiedCredentials;
+import java.util.function.Supplier;
 
 public class ConversationService implements com.sinch.sdk.domains.conversation.ConversationService {
 
   private final UnifiedCredentials credentials;
   private final ConversationContext context;
   private final ServerConfiguration oAuthServer;
-  private final HttpClient httpClient;
+  private final Supplier<HttpClient> httpClientSupplier;
 
   private com.sinch.sdk.domains.conversation.api.v1.ConversationService conversationV1;
   private TemplatesService templates;
@@ -20,25 +21,25 @@ public class ConversationService implements com.sinch.sdk.domains.conversation.C
       UnifiedCredentials credentials,
       ConversationContext context,
       ServerConfiguration oAuthServer,
-      HttpClient httpClient) {
+      Supplier<HttpClient> httpClientSupplier) {
     this.credentials = credentials;
     this.context = context;
     this.oAuthServer = oAuthServer;
-    this.httpClient = httpClient;
+    this.httpClientSupplier = httpClientSupplier;
   }
 
   public com.sinch.sdk.domains.conversation.api.v1.ConversationService v1() {
     if (null == this.conversationV1) {
       this.conversationV1 =
           new com.sinch.sdk.domains.conversation.api.v1.adapters.ConversationService(
-              credentials, context, oAuthServer, httpClient);
+              credentials, context, oAuthServer, httpClientSupplier);
     }
     return this.conversationV1;
   }
 
   public TemplatesService templates() {
     if (null == this.templates) {
-      this.templates = new TemplatesService(credentials, context, oAuthServer, httpClient);
+      this.templates = new TemplatesService(credentials, context, oAuthServer, httpClientSupplier);
     }
     return this.templates;
   }

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/templates/adapters/TemplatesService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/templates/adapters/TemplatesService.java
@@ -90,7 +90,8 @@ public class TemplatesService
             "Templates service requires 'templateManagementUrl' to be defined");
 
         OAuthManager authManager =
-            new OAuthManager(credentials, oAuthServer, new HttpMapper(), httpClientSupplier);
+            new OAuthManager(
+                credentials, oAuthServer, HttpMapper.getInstance(), httpClientSupplier);
         authManagers =
             Stream.of(new AbstractMap.SimpleEntry<>(SECURITY_SCHEME_KEYWORD_, authManager))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/templates/adapters/v1/TemplatesServiceV1.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/templates/adapters/v1/TemplatesServiceV1.java
@@ -23,7 +23,10 @@ public class TemplatesServiceV1
     this.uriUUID = uriUUID;
     this.api =
         new TemplatesV1Api(
-            httpClient, context.getTemplateManagementServer(), authManagers, new HttpMapper());
+            httpClient,
+            context.getTemplateManagementServer(),
+            authManagers,
+            HttpMapper.getInstance());
   }
 
   protected TemplatesV1Api getApi() {

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/templates/adapters/v2/TemplatesServiceV2.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/templates/adapters/v2/TemplatesServiceV2.java
@@ -28,7 +28,10 @@ public class TemplatesServiceV2
     this.uriUUID = uriUUID;
     this.api =
         new TemplatesV2Api(
-            httpClient, context.getTemplateManagementServer(), authManagers, new HttpMapper());
+            httpClient,
+            context.getTemplateManagementServer(),
+            authManagers,
+            HttpMapper.getInstance());
   }
 
   protected TemplatesV2Api getApi() {

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/AppService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/AppService.java
@@ -23,7 +23,7 @@ public class AppService implements com.sinch.sdk.domains.conversation.api.v1.App
       HttpClient httpClient,
       Map<String, AuthManager> authManagers) {
     this.uriUUID = uriUUID;
-    this.api = new AppApi(httpClient, context.getServer(), authManagers, new HttpMapper());
+    this.api = new AppApi(httpClient, context.getServer(), authManagers, HttpMapper.getInstance());
   }
 
   protected AppApi getApi() {

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/CapabilityService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/CapabilityService.java
@@ -21,7 +21,8 @@ public class CapabilityService
       HttpClient httpClient,
       Map<String, AuthManager> authManagers) {
     this.uriUUID = uriUUID;
-    this.api = new CapabilityApi(httpClient, context.getServer(), authManagers, new HttpMapper());
+    this.api =
+        new CapabilityApi(httpClient, context.getServer(), authManagers, HttpMapper.getInstance());
   }
 
   protected CapabilityApi getApi() {

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/ContactService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/ContactService.java
@@ -42,7 +42,8 @@ public class ContactService implements com.sinch.sdk.domains.conversation.api.v1
       HttpClient httpClient,
       Map<String, AuthManager> authManagers) {
     this.uriUUID = uriUUID;
-    this.api = new ContactApi(httpClient, context.getServer(), authManagers, new HttpMapper());
+    this.api =
+        new ContactApi(httpClient, context.getServer(), authManagers, HttpMapper.getInstance());
   }
 
   protected ContactApi getApi() {

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/ConversationService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/ConversationService.java
@@ -57,8 +57,6 @@ public class ConversationService
   private volatile TranscodingService transcoding;
   private volatile CapabilityService capability;
   private volatile WebHooksService webhooks;
-  private volatile WebHooksService webhooksCallbackService;
-
   private volatile TemplatesService templates;
 
   static {
@@ -105,7 +103,7 @@ public class ConversationService
   public WebHooksService webhooks() {
     if (null == this.webhooks) {
       this.webhooks =
-          new WebHooksProxyService(
+          new WebHooksAdaptorService(
               this::processCredentials,
               new WebHooksApiService(uriUUID, context, httpClient, authManagers),
               new WebHooksCallbackService(new HmacAuthenticationValidation()));

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/ConversationService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/ConversationService.java
@@ -171,7 +171,8 @@ public class ConversationService
             context.getUrl(), "Conversation service requires 'url' to be defined");
 
         OAuthManager authManager =
-            new OAuthManager(credentials, oAuthServer, new HttpMapper(), httpClientSupplier);
+            new OAuthManager(
+                credentials, oAuthServer, HttpMapper.getInstance(), httpClientSupplier);
         authManagers =
             Stream.of(new AbstractMap.SimpleEntry<>(SECURITY_SCHEME_KEYWORD_, authManager))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/ConversationsService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/ConversationsService.java
@@ -41,7 +41,9 @@ public class ConversationsService
       HttpClient httpClient,
       Map<String, AuthManager> authManagers) {
     this.uriUUID = uriUUID;
-    this.api = new ConversationApi(httpClient, context.getServer(), authManagers, new HttpMapper());
+    this.api =
+        new ConversationApi(
+            httpClient, context.getServer(), authManagers, HttpMapper.getInstance());
   }
 
   protected ConversationApi getApi() {

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/EventsService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/EventsService.java
@@ -30,7 +30,8 @@ public class EventsService implements com.sinch.sdk.domains.conversation.api.v1.
       HttpClient httpClient,
       Map<String, AuthManager> authManagers) {
     this.uriUUID = uriUUID;
-    this.api = new EventsApi(httpClient, context.getServer(), authManagers, new HttpMapper());
+    this.api =
+        new EventsApi(httpClient, context.getServer(), authManagers, HttpMapper.getInstance());
   }
 
   protected EventsApi getApi() {

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/MessagesService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/MessagesService.java
@@ -47,7 +47,8 @@ public class MessagesService implements com.sinch.sdk.domains.conversation.api.v
       HttpClient httpClient,
       Map<String, AuthManager> authManagers) {
     this.uriUUID = uriUUID;
-    this.api = new MessagesApi(httpClient, context.getServer(), authManagers, new HttpMapper());
+    this.api =
+        new MessagesApi(httpClient, context.getServer(), authManagers, HttpMapper.getInstance());
   }
 
   protected MessagesApi getApi() {

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/TranscodingService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/TranscodingService.java
@@ -21,7 +21,8 @@ public class TranscodingService
       HttpClient httpClient,
       Map<String, AuthManager> authManagers) {
     this.uriUUID = uriUUID;
-    this.api = new TranscodingApi(httpClient, context.getServer(), authManagers, new HttpMapper());
+    this.api =
+        new TranscodingApi(httpClient, context.getServer(), authManagers, HttpMapper.getInstance());
   }
 
   protected TranscodingApi getApi() {

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksAdaptorService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksAdaptorService.java
@@ -6,14 +6,14 @@ import com.sinch.sdk.domains.conversation.models.v1.webhooks.events.Conversation
 import java.util.Collection;
 import java.util.Map;
 
-public class WebHooksProxyService
+public class WebHooksAdaptorService
     implements com.sinch.sdk.domains.conversation.api.v1.WebHooksService {
 
   private final WebHooksApiService apiService;
   private final WebHooksCallbackService callbackService;
   private final Runnable credentialValidation;
 
-  public WebHooksProxyService(
+  public WebHooksAdaptorService(
       Runnable credentialValidation,
       WebHooksApiService apiService,
       WebHooksCallbackService callbackService) {

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksAdaptorService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksAdaptorService.java
@@ -1,25 +1,38 @@
 package com.sinch.sdk.domains.conversation.api.v1.adapters;
 
+import com.sinch.sdk.auth.HmacAuthenticationValidation;
 import com.sinch.sdk.core.exceptions.ApiMappingException;
+import com.sinch.sdk.core.http.AuthManager;
+import com.sinch.sdk.core.http.HttpClient;
 import com.sinch.sdk.domains.conversation.models.v1.webhooks.Webhook;
 import com.sinch.sdk.domains.conversation.models.v1.webhooks.events.ConversationWebhookEvent;
+import com.sinch.sdk.models.ConversationContext;
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class WebHooksAdaptorService
     implements com.sinch.sdk.domains.conversation.api.v1.WebHooksService {
 
-  private final WebHooksApiService apiService;
-  private final WebHooksCallbackService callbackService;
-  private final Runnable credentialValidation;
+  private final Runnable instanceLazyInit;
+  private final Supplier<Map<String, AuthManager>> authManagersSupplier;
+  private final String uriUUID;
+  private final ConversationContext context;
+  private final Supplier<HttpClient> httpClientSupplier;
+  private volatile WebHooksApiService apiService;
+  private volatile WebHooksCallbackService callbackService;
 
   public WebHooksAdaptorService(
-      Runnable credentialValidation,
-      WebHooksApiService apiService,
-      WebHooksCallbackService callbackService) {
-    this.credentialValidation = credentialValidation;
-    this.apiService = apiService;
-    this.callbackService = callbackService;
+      String uriUUID,
+      ConversationContext context,
+      Runnable instanceLazyInit,
+      Supplier<HttpClient> httpClientSupplier,
+      Supplier<Map<String, AuthManager>> authManagersSupplier) {
+    this.uriUUID = uriUUID;
+    this.context = context;
+    this.instanceLazyInit = instanceLazyInit;
+    this.httpClientSupplier = httpClientSupplier;
+    this.authManagersSupplier = authManagersSupplier;
   }
 
   public Collection<Webhook> list(String appId) {
@@ -43,21 +56,35 @@ public class WebHooksAdaptorService
   }
 
   WebHooksApiService activateApiService() {
-    validateCredentials();
-    return apiService;
+
+    if (null == this.apiService) {
+      instanceLazyInit.run();
+      this.apiService =
+          new WebHooksApiService(
+              uriUUID, context, httpClientSupplier.get(), authManagersSupplier.get());
+    }
+    return getApiService();
+  }
+
+  protected WebHooksApiService getApiService() {
+    return this.apiService;
+  }
+
+  WebHooksCallbackService activateCallbackApiService() {
+
+    if (null == this.callbackService) {
+      this.callbackService = new WebHooksCallbackService(new HmacAuthenticationValidation());
+    }
+    return callbackService;
   }
 
   public boolean validateAuthenticationHeader(
       String secret, Map<String, String> headers, String jsonPayload) {
-    return callbackService.validateAuthenticationHeader(secret, headers, jsonPayload);
+    return activateCallbackApiService().validateAuthenticationHeader(secret, headers, jsonPayload);
   }
 
   @Override
   public ConversationWebhookEvent parseEvent(String jsonPayload) throws ApiMappingException {
-    return callbackService.parseEvent(jsonPayload);
-  }
-
-  private void validateCredentials() {
-    credentialValidation.run();
+    return activateCallbackApiService().parseEvent(jsonPayload);
   }
 }

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksApiService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksApiService.java
@@ -29,7 +29,8 @@ public class WebHooksApiService
       HttpClient httpClient,
       Map<String, AuthManager> authManagers) {
     this.uriUUID = uriUUID;
-    this.api = new WebhooksApi(httpClient, context.getServer(), authManagers, new HttpMapper());
+    this.api =
+        new WebhooksApi(httpClient, context.getServer(), authManagers, HttpMapper.getInstance());
   }
 
   protected WebhooksApi getApi() {

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksApiService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksApiService.java
@@ -1,17 +1,13 @@
 package com.sinch.sdk.domains.conversation.api.v1.adapters;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.sinch.sdk.auth.HmacAuthenticationValidation;
 import com.sinch.sdk.core.exceptions.ApiMappingException;
 import com.sinch.sdk.core.http.AuthManager;
 import com.sinch.sdk.core.http.HttpClient;
 import com.sinch.sdk.core.http.HttpMapper;
-import com.sinch.sdk.core.utils.databind.Mapper;
 import com.sinch.sdk.domains.conversation.api.v1.internal.WebhooksApi;
 import com.sinch.sdk.domains.conversation.models.v1.webhooks.Webhook;
 import com.sinch.sdk.domains.conversation.models.v1.webhooks.WebhookImpl;
 import com.sinch.sdk.domains.conversation.models.v1.webhooks.events.ConversationWebhookEvent;
-import com.sinch.sdk.domains.conversation.models.v1.webhooks.events.internal.ConversationEventInternalImpl;
 import com.sinch.sdk.domains.conversation.models.v1.webhooks.internal.CreateWebhookRequestInternal;
 import com.sinch.sdk.domains.conversation.models.v1.webhooks.response.ListWebhooksResponse;
 import com.sinch.sdk.models.ConversationContext;
@@ -21,20 +17,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class WebHooksService implements com.sinch.sdk.domains.conversation.api.v1.WebHooksService {
-
-  private final HmacAuthenticationValidation authenticationChecker;
+public class WebHooksApiService
+    implements com.sinch.sdk.domains.conversation.api.v1.WebHooksService {
 
   private final String uriUUID;
   private final WebhooksApi api;
 
-  public WebHooksService(
+  public WebHooksApiService(
       String uriUUID,
       ConversationContext context,
       HttpClient httpClient,
-      Map<String, AuthManager> authManagers,
-      HmacAuthenticationValidation authenticationChecker) {
-    this.authenticationChecker = authenticationChecker;
+      Map<String, AuthManager> authManagers) {
     this.uriUUID = uriUUID;
     this.api = new WebhooksApi(httpClient, context.getServer(), authManagers, new HttpMapper());
   }
@@ -95,18 +88,11 @@ public class WebHooksService implements com.sinch.sdk.domains.conversation.api.v
 
   public boolean validateAuthenticationHeader(
       String secret, Map<String, String> headers, String jsonPayload) {
-
-    return authenticationChecker.validateAuthenticationHeader(secret, headers, jsonPayload);
+    throw new UnsupportedOperationException();
   }
 
   @Override
   public ConversationWebhookEvent parseEvent(String jsonPayload) throws ApiMappingException {
-    try {
-      ConversationEventInternalImpl dto =
-          Mapper.getInstance().readValue(jsonPayload, ConversationEventInternalImpl.class);
-      return (ConversationWebhookEvent) dto.getActualInstance();
-    } catch (JsonProcessingException e) {
-      throw new ApiMappingException(jsonPayload, e);
-    }
+    throw new UnsupportedOperationException();
   }
 }

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksCallbackService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksCallbackService.java
@@ -1,0 +1,58 @@
+package com.sinch.sdk.domains.conversation.api.v1.adapters;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.sinch.sdk.auth.HmacAuthenticationValidation;
+import com.sinch.sdk.core.exceptions.ApiMappingException;
+import com.sinch.sdk.core.utils.databind.Mapper;
+import com.sinch.sdk.domains.conversation.models.v1.webhooks.Webhook;
+import com.sinch.sdk.domains.conversation.models.v1.webhooks.events.ConversationWebhookEvent;
+import com.sinch.sdk.domains.conversation.models.v1.webhooks.events.internal.ConversationEventInternalImpl;
+import java.util.Collection;
+import java.util.Map;
+
+public class WebHooksCallbackService
+    implements com.sinch.sdk.domains.conversation.api.v1.WebHooksService {
+
+  private final HmacAuthenticationValidation authenticationChecker;
+
+  public WebHooksCallbackService(HmacAuthenticationValidation authenticationChecker) {
+    this.authenticationChecker = authenticationChecker;
+  }
+
+  public Collection<Webhook> list(String appId) {
+    throw new UnsupportedOperationException();
+  }
+
+  public Webhook get(String webhookId) {
+    throw new UnsupportedOperationException();
+  }
+
+  public Webhook create(Webhook _webhook) {
+    throw new UnsupportedOperationException();
+  }
+
+  public Webhook update(String webhookId, Webhook _webhook) {
+    throw new UnsupportedOperationException();
+  }
+
+  public void delete(String webhookId) {
+    throw new UnsupportedOperationException();
+  }
+
+  public boolean validateAuthenticationHeader(
+      String secret, Map<String, String> headers, String jsonPayload) {
+
+    return authenticationChecker.validateAuthenticationHeader(secret, headers, jsonPayload);
+  }
+
+  @Override
+  public ConversationWebhookEvent parseEvent(String jsonPayload) throws ApiMappingException {
+    try {
+      ConversationEventInternalImpl dto =
+          Mapper.getInstance().readValue(jsonPayload, ConversationEventInternalImpl.class);
+      return (ConversationWebhookEvent) dto.getActualInstance();
+    } catch (JsonProcessingException e) {
+      throw new ApiMappingException(jsonPayload, e);
+    }
+  }
+}

--- a/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksProxyService.java
+++ b/client/src/main/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksProxyService.java
@@ -1,0 +1,63 @@
+package com.sinch.sdk.domains.conversation.api.v1.adapters;
+
+import com.sinch.sdk.core.exceptions.ApiMappingException;
+import com.sinch.sdk.domains.conversation.models.v1.webhooks.Webhook;
+import com.sinch.sdk.domains.conversation.models.v1.webhooks.events.ConversationWebhookEvent;
+import java.util.Collection;
+import java.util.Map;
+
+public class WebHooksProxyService
+    implements com.sinch.sdk.domains.conversation.api.v1.WebHooksService {
+
+  private final WebHooksApiService apiService;
+  private final WebHooksCallbackService callbackService;
+  private final Runnable credentialValidation;
+
+  public WebHooksProxyService(
+      Runnable credentialValidation,
+      WebHooksApiService apiService,
+      WebHooksCallbackService callbackService) {
+    this.credentialValidation = credentialValidation;
+    this.apiService = apiService;
+    this.callbackService = callbackService;
+  }
+
+  public Collection<Webhook> list(String appId) {
+    return activateApiService().list(appId);
+  }
+
+  public Webhook get(String webhookId) {
+    return activateApiService().get(webhookId);
+  }
+
+  public Webhook create(Webhook _webhook) {
+    return activateApiService().create(_webhook);
+  }
+
+  public Webhook update(String webhookId, Webhook _webhook) {
+    return activateApiService().update(webhookId, _webhook);
+  }
+
+  public void delete(String webhookId) {
+    activateApiService().delete(webhookId);
+  }
+
+  WebHooksApiService activateApiService() {
+    validateCredentials();
+    return apiService;
+  }
+
+  public boolean validateAuthenticationHeader(
+      String secret, Map<String, String> headers, String jsonPayload) {
+    return callbackService.validateAuthenticationHeader(secret, headers, jsonPayload);
+  }
+
+  @Override
+  public ConversationWebhookEvent parseEvent(String jsonPayload) throws ApiMappingException {
+    return callbackService.parseEvent(jsonPayload);
+  }
+
+  private void validateCredentials() {
+    credentialValidation.run();
+  }
+}

--- a/client/src/main/com/sinch/sdk/domains/sms/adapters/SMSService.java
+++ b/client/src/main/com/sinch/sdk/domains/sms/adapters/SMSService.java
@@ -53,7 +53,7 @@ public class SMSService implements com.sinch.sdk.domains.sms.SMSService {
     LOGGER.fine("Activate SMS API with server='" + context.getSmsServer().getUrl() + "'");
 
     OAuthManager oAuthManager =
-        new OAuthManager(credentials, oAuthServer, new HttpMapper(), httpClient);
+        new OAuthManager(credentials, oAuthServer, new HttpMapper(), () -> httpClient);
 
     this.uriUUID = credentials.getProjectId();
     this.context = context;

--- a/client/src/main/com/sinch/sdk/domains/sms/api/v1/adapters/SMSService.java
+++ b/client/src/main/com/sinch/sdk/domains/sms/api/v1/adapters/SMSService.java
@@ -54,7 +54,7 @@ public class SMSService implements com.sinch.sdk.domains.sms.api.v1.SMSService {
     LOGGER.fine("Activate SMS API with server='" + context.getSmsServer().getUrl() + "'");
 
     OAuthManager oAuthManager =
-        new OAuthManager(credentials, oAuthServer, HttpMapper.getInstance(), httpClient);
+        new OAuthManager(credentials, oAuthServer, HttpMapper.getInstance(), () -> httpClient);
 
     this.uriUUID = credentials.getProjectId();
     this.context = context;

--- a/client/src/test/java/com/sinch/sdk/SinchClientTest.java
+++ b/client/src/test/java/com/sinch/sdk/SinchClientTest.java
@@ -12,6 +12,18 @@ import org.junit.jupiter.api.Test;
 class SinchClientTest {
 
   @Test
+  void configurationNullGuard() {
+    SinchClient client = new SinchClient(null);
+    assertNotNull(client);
+  }
+
+  @Test
+  void noConfiguration() {
+    SinchClient client = new SinchClient();
+    assertNotNull(client);
+  }
+
+  @Test
   void defaultOAuthUrlAvailable() {
     Configuration configuration =
         Configuration.builder().setKeyId("foo").setKeySecret("foo").setProjectId("foo").build();

--- a/client/src/test/java/com/sinch/sdk/auth/adapters/OAuthManagerTest.java
+++ b/client/src/test/java/com/sinch/sdk/auth/adapters/OAuthManagerTest.java
@@ -47,7 +47,7 @@ public class OAuthManagerTest extends BaseTest {
   public void initEach() {
     authManager =
         new OAuthManager(
-            credentials, new ServerConfiguration("OAuth url"), new HttpMapper(), httpClient);
+            credentials, new ServerConfiguration("OAuth url"), new HttpMapper(), () -> httpClient);
   }
 
   @Test

--- a/client/src/test/java/com/sinch/sdk/core/adapters/apache/HttpClientTestIT.java
+++ b/client/src/test/java/com/sinch/sdk/core/adapters/apache/HttpClientTestIT.java
@@ -45,7 +45,8 @@ class HttpClientTestIT extends BaseTest {
   HttpClientApache httpClient = new HttpClientApache();
 
   AuthManager basicAuthManager = new BasicAuthManager(credentials);
-  OAuthManager oAuthManager = new OAuthManager(credentials, server, new HttpMapper(), httpClient);
+  OAuthManager oAuthManager =
+      new OAuthManager(credentials, server, new HttpMapper(), () -> httpClient);
 
   Map<String, AuthManager> authManagers =
       Stream.of(basicAuthManager, oAuthManager)

--- a/client/src/test/java/com/sinch/sdk/domains/conversation/api/templates/adapters/CredentialsValidationHelper.java
+++ b/client/src/test/java/com/sinch/sdk/domains/conversation/api/templates/adapters/CredentialsValidationHelper.java
@@ -1,4 +1,4 @@
-package com.sinch.sdk.domains.conversation.api.v1.adapters;
+package com.sinch.sdk.domains.conversation.api.templates.adapters;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -12,21 +12,22 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 class CredentialsValidationHelper {
-  static void checkCredentials(
-      Supplier<HttpClient> httpClientSupplier, Consumer<ConversationService> service) {
 
-    doNotAcceptNullKey(httpClientSupplier, service);
-    doNotAcceptNullKeySecret(httpClientSupplier, service);
-    doNotAcceptNullProject(httpClientSupplier, service);
-    doNotAcceptNullCredentials(httpClientSupplier, service);
-    doNotAcceptNullContext(httpClientSupplier, service);
-    doNotAcceptEmptyURL(httpClientSupplier, service);
-    doNotAcceptNullURL(httpClientSupplier, service);
-    passInit(httpClientSupplier, service);
+  static void checkCredentialsTemplates(
+      Supplier<HttpClient> httpClientSupplier, Consumer<TemplatesService> service) {
+
+    doNotAcceptNullKeyTemplates(httpClientSupplier, service);
+    doNotAcceptNullKeySecretTemplates(httpClientSupplier, service);
+    doNotAcceptNullProjectTemplates(httpClientSupplier, service);
+    doNotAcceptNullCredentialsTemplates(httpClientSupplier, service);
+    doNotAcceptNullContextTemplates(httpClientSupplier, service);
+    doNotAcceptEmptyURLTemplates(httpClientSupplier, service);
+    doNotAcceptNullURLTemplates(httpClientSupplier, service);
+    passInitTemplates(httpClientSupplier, service);
   }
 
-  private static void doNotAcceptNullKey(
-      Supplier<HttpClient> httpClientSupplier, Consumer<ConversationService> service) {
+  private static void doNotAcceptNullKeyTemplates(
+      Supplier<HttpClient> httpClientSupplier, Consumer<TemplatesService> service) {
     UnifiedCredentials credentials =
         UnifiedCredentials.builder().setKeyId(null).setKeySecret("foo").setProjectId("foo").build();
     ConversationContext context = ConversationContext.builder().build();
@@ -36,12 +37,12 @@ class CredentialsValidationHelper {
             IllegalArgumentException.class,
             () ->
                 service.accept(
-                    new ConversationService(credentials, context, server, httpClientSupplier)));
+                    new TemplatesService(credentials, context, server, httpClientSupplier)));
     assertTrue(exception.getMessage().contains("keyId"));
   }
 
-  private static void doNotAcceptNullKeySecret(
-      Supplier<HttpClient> httpClientSupplier, Consumer<ConversationService> service) {
+  private static void doNotAcceptNullKeySecretTemplates(
+      Supplier<HttpClient> httpClientSupplier, Consumer<TemplatesService> service) {
     UnifiedCredentials credentials =
         UnifiedCredentials.builder().setKeyId("foo").setKeySecret(null).setProjectId("foo").build();
     ConversationContext context = ConversationContext.builder().build();
@@ -51,12 +52,12 @@ class CredentialsValidationHelper {
             IllegalArgumentException.class,
             () ->
                 service.accept(
-                    new ConversationService(credentials, context, server, httpClientSupplier)));
+                    new TemplatesService(credentials, context, server, httpClientSupplier)));
     assertTrue(exception.getMessage().contains("keySecret"));
   }
 
-  private static void doNotAcceptNullProject(
-      Supplier<HttpClient> httpClientSupplier, Consumer<ConversationService> service) {
+  private static void doNotAcceptNullProjectTemplates(
+      Supplier<HttpClient> httpClientSupplier, Consumer<TemplatesService> service) {
     UnifiedCredentials credentials =
         UnifiedCredentials.builder().setKeyId("foo").setKeySecret("foo").setProjectId(null).build();
     ConversationContext context = ConversationContext.builder().build();
@@ -67,25 +68,24 @@ class CredentialsValidationHelper {
             IllegalArgumentException.class,
             () ->
                 service.accept(
-                    new ConversationService(credentials, context, server, httpClientSupplier)));
+                    new TemplatesService(credentials, context, server, httpClientSupplier)));
     assertTrue(exception.getMessage().contains("projectId"));
   }
 
-  private static void doNotAcceptNullCredentials(
-      Supplier<HttpClient> httpClientSupplier, Consumer<ConversationService> service) {
+  private static void doNotAcceptNullCredentialsTemplates(
+      Supplier<HttpClient> httpClientSupplier, Consumer<TemplatesService> service) {
     ConversationContext context = ConversationContext.builder().build();
     ServerConfiguration server = new ServerConfiguration("");
     Exception exception =
         assertThrows(
             NullPointerException.class,
-            () ->
-                service.accept(new ConversationService(null, context, server, httpClientSupplier)));
+            () -> service.accept(new TemplatesService(null, context, server, httpClientSupplier)));
     assertTrue(
-        exception.getMessage().contains("Conversation service requires credentials to be defined"));
+        exception.getMessage().contains("Templates service requires credentials to be defined"));
   }
 
-  private static void doNotAcceptNullContext(
-      Supplier<HttpClient> httpClientSupplier, Consumer<ConversationService> service) {
+  private static void doNotAcceptNullContextTemplates(
+      Supplier<HttpClient> httpClientSupplier, Consumer<TemplatesService> service) {
     UnifiedCredentials credentials =
         UnifiedCredentials.builder()
             .setKeyId("foo")
@@ -98,13 +98,12 @@ class CredentialsValidationHelper {
             NullPointerException.class,
             () ->
                 service.accept(
-                    new ConversationService(credentials, null, server, httpClientSupplier)));
-    assertTrue(
-        exception.getMessage().contains("Conversation service requires context to be defined"));
+                    new TemplatesService(credentials, null, server, httpClientSupplier)));
+    assertTrue(exception.getMessage().contains("Templates service requires context to be defined"));
   }
 
-  private static void doNotAcceptEmptyURL(
-      Supplier<HttpClient> httpClientSupplier, Consumer<ConversationService> service) {
+  private static void doNotAcceptEmptyURLTemplates(
+      Supplier<HttpClient> httpClientSupplier, Consumer<TemplatesService> service) {
     UnifiedCredentials credentials =
         UnifiedCredentials.builder()
             .setKeyId("foo")
@@ -118,13 +117,15 @@ class CredentialsValidationHelper {
             IllegalArgumentException.class,
             () ->
                 service.accept(
-                    new ConversationService(credentials, context, server, httpClientSupplier)));
+                    new TemplatesService(credentials, context, server, httpClientSupplier)));
     assertTrue(
-        exception.getMessage().contains("Conversation service requires 'url' to be defined"));
+        exception
+            .getMessage()
+            .contains("Templates service requires 'templateManagementUrl' to be defined"));
   }
 
-  private static void doNotAcceptNullURL(
-      Supplier<HttpClient> httpClientSupplier, Consumer<ConversationService> service) {
+  private static void doNotAcceptNullURLTemplates(
+      Supplier<HttpClient> httpClientSupplier, Consumer<TemplatesService> service) {
     UnifiedCredentials credentials =
         UnifiedCredentials.builder()
             .setKeyId("foo")
@@ -138,25 +139,27 @@ class CredentialsValidationHelper {
             IllegalArgumentException.class,
             () ->
                 service.accept(
-                    new ConversationService(credentials, context, server, httpClientSupplier)));
+                    new TemplatesService(credentials, context, server, httpClientSupplier)));
     assertTrue(
-        exception.getMessage().contains("Conversation service requires 'url' to be defined"));
+        exception
+            .getMessage()
+            .contains("Templates service requires 'templateManagementUrl' to be defined"));
   }
 
-  private static void passInit(
-      Supplier<HttpClient> httpClientSupplier, Consumer<ConversationService> service) {
+  private static void passInitTemplates(
+      Supplier<HttpClient> httpClientSupplier, Consumer<TemplatesService> service) {
     UnifiedCredentials credentials =
         UnifiedCredentials.builder()
             .setKeyId("foo")
             .setKeySecret("foo")
             .setProjectId("foo")
             .build();
-    ConversationContext context = ConversationContext.builder().setUrl("foo").build();
+    ConversationContext context =
+        ConversationContext.builder().setTemplateManagementUrl("foo").build();
     ServerConfiguration server = new ServerConfiguration("foo");
     assertDoesNotThrow(
         () ->
-            service.accept(
-                new ConversationService(credentials, context, server, httpClientSupplier)),
+            service.accept(new TemplatesService(credentials, context, server, httpClientSupplier)),
         "Init passed");
   }
 }

--- a/client/src/test/java/com/sinch/sdk/domains/conversation/api/templates/adapters/TemplateServiceTest.java
+++ b/client/src/test/java/com/sinch/sdk/domains/conversation/api/templates/adapters/TemplateServiceTest.java
@@ -1,13 +1,8 @@
 package com.sinch.sdk.domains.conversation.api.templates.adapters;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.sinch.sdk.core.http.HttpClient;
-import com.sinch.sdk.core.models.ServerConfiguration;
-import com.sinch.sdk.models.ConversationContext;
-import com.sinch.sdk.models.UnifiedCredentials;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
@@ -16,126 +11,17 @@ class TemplateServiceTest {
   @Mock HttpClient httpClient;
 
   @Test
-  void doNotAcceptNullKey() {
-    UnifiedCredentials credentials =
-        UnifiedCredentials.builder().setKeyId(null).setKeySecret("foo").setProjectId("foo").build();
-    ConversationContext context = ConversationContext.builder().build();
-    ServerConfiguration server = new ServerConfiguration("foo");
-    Exception exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new TemplatesService(credentials, context, server, httpClient));
-    assertTrue(exception.getMessage().contains("keyId"));
+  void checkCredentialsV1() {
+    CredentialsValidationHelper.checkCredentialsTemplates(() -> httpClient, TemplatesService::v1);
   }
 
   @Test
-  void doNotAcceptNullKeySecret() {
-    UnifiedCredentials credentials =
-        UnifiedCredentials.builder().setKeyId("foo").setKeySecret(null).setProjectId("foo").build();
-    ConversationContext context = ConversationContext.builder().build();
-    ServerConfiguration server = new ServerConfiguration("foo");
-    Exception exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new TemplatesService(credentials, context, server, httpClient));
-    assertTrue(exception.getMessage().contains("keySecret"));
+  void checkCredentialsV2() {
+    CredentialsValidationHelper.checkCredentialsTemplates(() -> httpClient, TemplatesService::v2);
   }
 
   @Test
-  void doNotAcceptNullProject() {
-    UnifiedCredentials credentials =
-        UnifiedCredentials.builder().setKeyId("foo").setKeySecret("foo").setProjectId(null).build();
-    ConversationContext context = ConversationContext.builder().build();
-    ServerConfiguration server = new ServerConfiguration("foo");
-    Exception exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new TemplatesService(credentials, context, server, httpClient));
-    assertTrue(exception.getMessage().contains("projectId"));
-  }
-
-  @Test
-  void doNotAcceptNullCredentials() {
-
-    ConversationContext context = ConversationContext.builder().build();
-    ServerConfiguration server = new ServerConfiguration("foo");
-    Exception exception =
-        assertThrows(
-            NullPointerException.class,
-            () -> new TemplatesService(null, context, server, httpClient));
-    assertTrue(
-        exception.getMessage().contains("Templates service requires credentials to be defined"));
-  }
-
-  @Test
-  void doNotAcceptNullContext() {
-    UnifiedCredentials credentials =
-        UnifiedCredentials.builder()
-            .setKeyId("foo")
-            .setKeySecret("foo")
-            .setProjectId("foo")
-            .build();
-    ServerConfiguration server = new ServerConfiguration("foo");
-    Exception exception =
-        assertThrows(
-            NullPointerException.class,
-            () -> new TemplatesService(credentials, null, server, httpClient));
-    assertTrue(exception.getMessage().contains("Templates service requires context to be defined"));
-  }
-
-  @Test
-  void doNotAcceptEmptyManagementURL() {
-    UnifiedCredentials credentials =
-        UnifiedCredentials.builder()
-            .setKeyId("foo")
-            .setKeySecret("foo")
-            .setProjectId("foo")
-            .build();
-    ConversationContext context =
-        ConversationContext.builder().setTemplateManagementUrl("").build();
-    ServerConfiguration server = new ServerConfiguration("");
-    Exception exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new TemplatesService(credentials, context, server, httpClient));
-    assertTrue(
-        exception
-            .getMessage()
-            .contains("Templates service requires 'templateManagementUrl' to be defined"));
-  }
-
-  @Test
-  void doNotAcceptNullManagementURL() {
-    UnifiedCredentials credentials =
-        UnifiedCredentials.builder()
-            .setKeyId("foo")
-            .setKeySecret("foo")
-            .setProjectId("foo")
-            .build();
-    ConversationContext context = ConversationContext.builder().build();
-    ServerConfiguration server = new ServerConfiguration("");
-    Exception exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new TemplatesService(credentials, context, server, httpClient));
-    assertTrue(
-        exception
-            .getMessage()
-            .contains("Templates service requires 'templateManagementUrl' to be defined"));
-  }
-
-  @Test
-  void passInit() {
-    UnifiedCredentials credentials =
-        UnifiedCredentials.builder()
-            .setKeyId("foo")
-            .setKeySecret("foo")
-            .setProjectId("foo")
-            .build();
-    ConversationContext context =
-        ConversationContext.builder().setTemplateManagementUrl("foo").build();
-    ServerConfiguration server = new ServerConfiguration("foo");
-    assertDoesNotThrow(
-        () -> new TemplatesService(credentials, context, server, httpClient), "Init passed");
+  void passInitWithoutSettings() {
+    assertDoesNotThrow(() -> new TemplatesService(null, null, null, null), "Init passed");
   }
 }

--- a/client/src/test/java/com/sinch/sdk/domains/conversation/api/v1/adapters/ConversationServiceTest.java
+++ b/client/src/test/java/com/sinch/sdk/domains/conversation/api/v1/adapters/ConversationServiceTest.java
@@ -1,13 +1,6 @@
 package com.sinch.sdk.domains.conversation.api.v1.adapters;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import com.sinch.sdk.core.http.HttpClient;
-import com.sinch.sdk.core.models.ServerConfiguration;
-import com.sinch.sdk.models.ConversationContext;
-import com.sinch.sdk.models.UnifiedCredentials;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
@@ -16,122 +9,37 @@ class ConversationServiceTest {
   @Mock HttpClient httpClient;
 
   @Test
-  void doNotAcceptNullKey() {
-    UnifiedCredentials credentials =
-        UnifiedCredentials.builder().setKeyId(null).setKeySecret("foo").setProjectId("foo").build();
-    ConversationContext context = ConversationContext.builder().build();
-    ServerConfiguration server = new ServerConfiguration("");
-    Exception exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new ConversationService(credentials, context, server, httpClient));
-    assertTrue(exception.getMessage().contains("keyId"));
+  void checkCredentialsApp() {
+    CredentialsValidationHelper.checkCredentials(httpClient, ConversationService::app);
   }
 
   @Test
-  void doNotAcceptNullKeySecret() {
-    UnifiedCredentials credentials =
-        UnifiedCredentials.builder().setKeyId("foo").setKeySecret(null).setProjectId("foo").build();
-    ConversationContext context = ConversationContext.builder().build();
-    ServerConfiguration server = new ServerConfiguration("");
-    Exception exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new ConversationService(credentials, context, server, httpClient));
-    assertTrue(exception.getMessage().contains("keySecret"));
+  void checkCredentialsCapability() {
+    CredentialsValidationHelper.checkCredentials(httpClient, ConversationService::capability);
   }
 
   @Test
-  void doNotAcceptNullProject() {
-    UnifiedCredentials credentials =
-        UnifiedCredentials.builder().setKeyId("foo").setKeySecret("foo").setProjectId(null).build();
-    ConversationContext context = ConversationContext.builder().build();
-    ServerConfiguration server = new ServerConfiguration("");
-
-    Exception exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new ConversationService(credentials, context, server, httpClient));
-    assertTrue(exception.getMessage().contains("projectId"));
+  void checkCredentialsContact() {
+    CredentialsValidationHelper.checkCredentials(httpClient, ConversationService::contact);
   }
 
   @Test
-  void doNotAcceptNullCredentials() {
-
-    ConversationContext context = ConversationContext.builder().build();
-    ServerConfiguration server = new ServerConfiguration("");
-    Exception exception =
-        assertThrows(
-            NullPointerException.class,
-            () -> new ConversationService(null, context, server, httpClient));
-    assertTrue(
-        exception.getMessage().contains("Conversation service requires credentials to be defined"));
+  void checkCredentialsConversations() {
+    CredentialsValidationHelper.checkCredentials(httpClient, ConversationService::conversations);
   }
 
   @Test
-  void doNotAcceptNullContext() {
-    UnifiedCredentials credentials =
-        UnifiedCredentials.builder()
-            .setKeyId("foo")
-            .setKeySecret("foo")
-            .setProjectId("foo")
-            .build();
-    ServerConfiguration server = new ServerConfiguration("");
-    Exception exception =
-        assertThrows(
-            NullPointerException.class,
-            () -> new ConversationService(credentials, null, server, httpClient));
-    assertTrue(
-        exception.getMessage().contains("Conversation service requires context to be defined"));
+  void checkCredentialsEvents() {
+    CredentialsValidationHelper.checkCredentials(httpClient, ConversationService::events);
   }
 
   @Test
-  void doNotAcceptEmptyURL() {
-    UnifiedCredentials credentials =
-        UnifiedCredentials.builder()
-            .setKeyId("foo")
-            .setKeySecret("foo")
-            .setProjectId("foo")
-            .build();
-    ConversationContext context = ConversationContext.builder().setUrl("").build();
-    ServerConfiguration server = new ServerConfiguration("");
-    Exception exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new ConversationService(credentials, context, server, httpClient));
-    assertTrue(
-        exception.getMessage().contains("Conversation service requires 'url' to be defined"));
+  void checkCredentialsMessages() {
+    CredentialsValidationHelper.checkCredentials(httpClient, ConversationService::messages);
   }
 
   @Test
-  void doNotAcceptNullURL() {
-    UnifiedCredentials credentials =
-        UnifiedCredentials.builder()
-            .setKeyId("foo")
-            .setKeySecret("foo")
-            .setProjectId("foo")
-            .build();
-    ConversationContext context = ConversationContext.builder().build();
-    ServerConfiguration server = new ServerConfiguration("");
-    Exception exception =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new ConversationService(credentials, context, server, httpClient));
-    assertTrue(
-        exception.getMessage().contains("Conversation service requires 'url' to be defined"));
-  }
-
-  @Test
-  void passInit() {
-    UnifiedCredentials credentials =
-        UnifiedCredentials.builder()
-            .setKeyId("foo")
-            .setKeySecret("foo")
-            .setProjectId("foo")
-            .build();
-    ConversationContext context = ConversationContext.builder().setUrl("foo").build();
-    ServerConfiguration server = new ServerConfiguration("foo");
-    assertDoesNotThrow(
-        () -> new ConversationService(credentials, context, server, httpClient), "Init passed");
+  void checkCredentialsTranscoding() {
+    CredentialsValidationHelper.checkCredentials(httpClient, ConversationService::transcoding);
   }
 }

--- a/client/src/test/java/com/sinch/sdk/domains/conversation/api/v1/adapters/ConversationServiceTest.java
+++ b/client/src/test/java/com/sinch/sdk/domains/conversation/api/v1/adapters/ConversationServiceTest.java
@@ -1,6 +1,9 @@
 package com.sinch.sdk.domains.conversation.api.v1.adapters;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 import com.sinch.sdk.core.http.HttpClient;
+import com.sinch.sdk.domains.conversation.api.templates.adapters.TemplatesService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
@@ -10,36 +13,43 @@ class ConversationServiceTest {
 
   @Test
   void checkCredentialsApp() {
-    CredentialsValidationHelper.checkCredentials(httpClient, ConversationService::app);
+    CredentialsValidationHelper.checkCredentials(() -> httpClient, ConversationService::app);
   }
 
   @Test
   void checkCredentialsCapability() {
-    CredentialsValidationHelper.checkCredentials(httpClient, ConversationService::capability);
+    CredentialsValidationHelper.checkCredentials(() -> httpClient, ConversationService::capability);
   }
 
   @Test
   void checkCredentialsContact() {
-    CredentialsValidationHelper.checkCredentials(httpClient, ConversationService::contact);
+    CredentialsValidationHelper.checkCredentials(() -> httpClient, ConversationService::contact);
   }
 
   @Test
   void checkCredentialsConversations() {
-    CredentialsValidationHelper.checkCredentials(httpClient, ConversationService::conversations);
+    CredentialsValidationHelper.checkCredentials(
+        () -> httpClient, ConversationService::conversations);
   }
 
   @Test
   void checkCredentialsEvents() {
-    CredentialsValidationHelper.checkCredentials(httpClient, ConversationService::events);
+    CredentialsValidationHelper.checkCredentials(() -> httpClient, ConversationService::events);
   }
 
   @Test
   void checkCredentialsMessages() {
-    CredentialsValidationHelper.checkCredentials(httpClient, ConversationService::messages);
+    CredentialsValidationHelper.checkCredentials(() -> httpClient, ConversationService::messages);
   }
 
   @Test
   void checkCredentialsTranscoding() {
-    CredentialsValidationHelper.checkCredentials(httpClient, ConversationService::transcoding);
+    CredentialsValidationHelper.checkCredentials(
+        () -> httpClient, ConversationService::transcoding);
+  }
+
+  @Test
+  void passInitWithoutSettings() {
+    assertDoesNotThrow(() -> new TemplatesService(null, null, null, null), "Init passed");
   }
 }

--- a/client/src/test/java/com/sinch/sdk/domains/conversation/api/v1/adapters/CredentialsValidationHelper.java
+++ b/client/src/test/java/com/sinch/sdk/domains/conversation/api/v1/adapters/CredentialsValidationHelper.java
@@ -1,0 +1,149 @@
+package com.sinch.sdk.domains.conversation.api.v1.adapters;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sinch.sdk.core.http.HttpClient;
+import com.sinch.sdk.core.models.ServerConfiguration;
+import com.sinch.sdk.models.ConversationContext;
+import com.sinch.sdk.models.UnifiedCredentials;
+import java.util.function.Consumer;
+
+class CredentialsValidationHelper {
+  static void checkCredentials(HttpClient httpClient, Consumer<ConversationService> service) {
+
+    doNotAcceptNullKey(httpClient, service);
+    doNotAcceptNullKeySecret(httpClient, service);
+    doNotAcceptNullProject(httpClient, service);
+    doNotAcceptNullCredentials(httpClient, service);
+    doNotAcceptNullContext(httpClient, service);
+    doNotAcceptEmptyURL(httpClient, service);
+    doNotAcceptNullURL(httpClient, service);
+    passInit(httpClient, service);
+  }
+
+  private static void doNotAcceptNullKey(
+      HttpClient httpClient, Consumer<ConversationService> service) {
+    UnifiedCredentials credentials =
+        UnifiedCredentials.builder().setKeyId(null).setKeySecret("foo").setProjectId("foo").build();
+    ConversationContext context = ConversationContext.builder().build();
+    ServerConfiguration server = new ServerConfiguration("");
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                service.accept(new ConversationService(credentials, context, server, httpClient)));
+    assertTrue(exception.getMessage().contains("keyId"));
+  }
+
+  private static void doNotAcceptNullKeySecret(
+      HttpClient httpClient, Consumer<ConversationService> service) {
+    UnifiedCredentials credentials =
+        UnifiedCredentials.builder().setKeyId("foo").setKeySecret(null).setProjectId("foo").build();
+    ConversationContext context = ConversationContext.builder().build();
+    ServerConfiguration server = new ServerConfiguration("");
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                service.accept(new ConversationService(credentials, context, server, httpClient)));
+    assertTrue(exception.getMessage().contains("keySecret"));
+  }
+
+  private static void doNotAcceptNullProject(
+      HttpClient httpClient, Consumer<ConversationService> service) {
+    UnifiedCredentials credentials =
+        UnifiedCredentials.builder().setKeyId("foo").setKeySecret("foo").setProjectId(null).build();
+    ConversationContext context = ConversationContext.builder().build();
+    ServerConfiguration server = new ServerConfiguration("");
+
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                service.accept(new ConversationService(credentials, context, server, httpClient)));
+    assertTrue(exception.getMessage().contains("projectId"));
+  }
+
+  private static void doNotAcceptNullCredentials(
+      HttpClient httpClient, Consumer<ConversationService> service) {
+    ConversationContext context = ConversationContext.builder().build();
+    ServerConfiguration server = new ServerConfiguration("");
+    Exception exception =
+        assertThrows(
+            NullPointerException.class,
+            () -> service.accept(new ConversationService(null, context, server, httpClient)));
+    assertTrue(
+        exception.getMessage().contains("Conversation service requires credentials to be defined"));
+  }
+
+  private static void doNotAcceptNullContext(
+      HttpClient httpClient, Consumer<ConversationService> service) {
+    UnifiedCredentials credentials =
+        UnifiedCredentials.builder()
+            .setKeyId("foo")
+            .setKeySecret("foo")
+            .setProjectId("foo")
+            .build();
+    ServerConfiguration server = new ServerConfiguration("");
+    Exception exception =
+        assertThrows(
+            NullPointerException.class,
+            () -> service.accept(new ConversationService(credentials, null, server, httpClient)));
+    assertTrue(
+        exception.getMessage().contains("Conversation service requires context to be defined"));
+  }
+
+  private static void doNotAcceptEmptyURL(
+      HttpClient httpClient, Consumer<ConversationService> service) {
+    UnifiedCredentials credentials =
+        UnifiedCredentials.builder()
+            .setKeyId("foo")
+            .setKeySecret("foo")
+            .setProjectId("foo")
+            .build();
+    ConversationContext context = ConversationContext.builder().setUrl("").build();
+    ServerConfiguration server = new ServerConfiguration("");
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                service.accept(new ConversationService(credentials, context, server, httpClient)));
+    assertTrue(
+        exception.getMessage().contains("Conversation service requires 'url' to be defined"));
+  }
+
+  private static void doNotAcceptNullURL(
+      HttpClient httpClient, Consumer<ConversationService> service) {
+    UnifiedCredentials credentials =
+        UnifiedCredentials.builder()
+            .setKeyId("foo")
+            .setKeySecret("foo")
+            .setProjectId("foo")
+            .build();
+    ConversationContext context = ConversationContext.builder().build();
+    ServerConfiguration server = new ServerConfiguration("");
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                service.accept(new ConversationService(credentials, context, server, httpClient)));
+    assertTrue(
+        exception.getMessage().contains("Conversation service requires 'url' to be defined"));
+  }
+
+  private static void passInit(HttpClient httpClient, Consumer<ConversationService> service) {
+    UnifiedCredentials credentials =
+        UnifiedCredentials.builder()
+            .setKeyId("foo")
+            .setKeySecret("foo")
+            .setProjectId("foo")
+            .build();
+    ConversationContext context = ConversationContext.builder().setUrl("foo").build();
+    ServerConfiguration server = new ServerConfiguration("foo");
+    assertDoesNotThrow(
+        () -> service.accept(new ConversationService(credentials, context, server, httpClient)),
+        "Init passed");
+  }
+}

--- a/client/src/test/java/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksAdaptorServiceTest.java
+++ b/client/src/test/java/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksAdaptorServiceTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 @TestWithResources
-public class WebHooksProxyServiceTest extends ConversationBaseTest {
+public class WebHooksAdaptorServiceTest extends ConversationBaseTest {
 
   WebHooksService service;
 
@@ -23,7 +23,7 @@ public class WebHooksProxyServiceTest extends ConversationBaseTest {
 
   @BeforeEach
   public void initMocks() {
-    service = spy(new WebHooksProxyService(credentialValidation, apiService, callbackService));
+    service = spy(new WebHooksAdaptorService(credentialValidation, apiService, callbackService));
   }
 
   @Test

--- a/client/src/test/java/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksAdaptorServiceTest.java
+++ b/client/src/test/java/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksAdaptorServiceTest.java
@@ -1,13 +1,20 @@
 package com.sinch.sdk.domains.conversation.api.v1.adapters;
 
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.adelean.inject.resources.junit.jupiter.GivenTextResource;
 import com.adelean.inject.resources.junit.jupiter.TestWithResources;
 import com.sinch.sdk.core.exceptions.ApiException;
-import com.sinch.sdk.domains.conversation.api.v1.WebHooksService;
+import com.sinch.sdk.core.http.AuthManager;
+import com.sinch.sdk.core.http.HttpClient;
 import com.sinch.sdk.domains.conversation.models.v1.webhooks.Webhook;
+import com.sinch.sdk.models.ConversationContext;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -15,19 +22,30 @@ import org.mockito.Mock;
 @TestWithResources
 public class WebHooksAdaptorServiceTest extends ConversationBaseTest {
 
-  WebHooksService service;
+  @GivenTextResource("domains/conversation/v1/webhooks/events/capability/CapabilityEventDto.json")
+  String jsonCapabilityEvent;
 
+  WebHooksAdaptorService service;
+
+  @Mock WebHooksApiService api;
+  @Mock ConversationContext context;
   @Mock Runnable credentialValidation;
-  @Mock WebHooksApiService apiService;
-  @Mock WebHooksCallbackService callbackService;
+  @Mock Supplier<HttpClient> httpClient;
+  @Mock Supplier<Map<String, AuthManager>> authManagers;
+
+  String uriPartID = "foovalue";
 
   @BeforeEach
   public void initMocks() {
-    service = spy(new WebHooksAdaptorService(credentialValidation, apiService, callbackService));
+    service =
+        spy(
+            new WebHooksAdaptorService(
+                uriPartID, context, credentialValidation, httpClient, authManagers));
   }
 
   @Test
   void list() throws ApiException {
+    doReturn(api).when(service).getApiService();
 
     service.list("foo");
 
@@ -36,6 +54,7 @@ public class WebHooksAdaptorServiceTest extends ConversationBaseTest {
 
   @Test
   void get() throws ApiException {
+    doReturn(api).when(service).getApiService();
 
     service.get("foo");
 
@@ -44,6 +63,7 @@ public class WebHooksAdaptorServiceTest extends ConversationBaseTest {
 
   @Test
   void create() throws ApiException {
+    doReturn(api).when(service).getApiService();
 
     service.create(Webhook.builder().build());
 
@@ -52,6 +72,7 @@ public class WebHooksAdaptorServiceTest extends ConversationBaseTest {
 
   @Test
   void update() throws ApiException {
+    doReturn(api).when(service).getApiService();
 
     service.update("foo", Webhook.builder().build());
 
@@ -60,9 +81,26 @@ public class WebHooksAdaptorServiceTest extends ConversationBaseTest {
 
   @Test
   void delete() throws ApiException {
+    doReturn(api).when(service).getApiService();
 
     service.delete("foo");
 
     verify(credentialValidation, times(1)).run();
+  }
+
+  @Test
+  void validateAuthenticationHeader() throws ApiException {
+
+    service.validateAuthenticationHeader("", new HashMap<>(), "");
+
+    verify(credentialValidation, times(0)).run();
+  }
+
+  @Test
+  void parseEvent() throws ApiException {
+
+    service.parseEvent(jsonCapabilityEvent);
+
+    verify(credentialValidation, times(0)).run();
   }
 }

--- a/client/src/test/java/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksApiServiceTest.java
+++ b/client/src/test/java/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksApiServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.adelean.inject.resources.junit.jupiter.TestWithResources;
-import com.sinch.sdk.auth.HmacAuthenticationValidation;
 import com.sinch.sdk.core.TestHelpers;
 import com.sinch.sdk.core.exceptions.ApiException;
 import com.sinch.sdk.core.http.AuthManager;
@@ -36,12 +35,11 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 
 @TestWithResources
-public class WebHooksClientServiceTest extends ConversationBaseTest {
+public class WebHooksApiServiceTest extends ConversationBaseTest {
   @Mock ConversationContext context;
   @Mock WebhooksApi api;
   @Mock HttpClient httpClient;
   @Mock Map<String, AuthManager> authManagers;
-  @Mock HmacAuthenticationValidation authenticationValidation;
 
   @Captor ArgumentCaptor<String> uriPartIDCaptor;
   @Captor ArgumentCaptor<String> idCaptor;
@@ -50,15 +48,12 @@ public class WebHooksClientServiceTest extends ConversationBaseTest {
 
   @Captor ArgumentCaptor<List<String>> maskCaptor;
 
-  WebHooksService service;
+  WebHooksApiService service;
   String uriPartID = "foovalue";
 
   @BeforeEach
   public void initMocks() {
-    service =
-        spy(
-            new WebHooksService(
-                uriPartID, context, httpClient, authManagers, authenticationValidation));
+    service = spy(new WebHooksApiService(uriPartID, context, httpClient, authManagers));
     doReturn(api).when(service).getApi();
   }
 

--- a/client/src/test/java/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksCallbackServiceTest.java
+++ b/client/src/test/java/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksCallbackServiceTest.java
@@ -28,7 +28,6 @@ import com.sinch.sdk.domains.conversation.models.v1.webhooks.events.record.Recor
 import com.sinch.sdk.domains.conversation.models.v1.webhooks.events.smartconversations.MessageInboundSmartConversationRedactionEvent;
 import com.sinch.sdk.domains.conversation.models.v1.webhooks.events.smartconversations.SmartConversationsEvent;
 import com.sinch.sdk.domains.conversation.models.v1.webhooks.events.unsupported.UnsupportedCallbackEvent;
-import com.sinch.sdk.models.Configuration;
 import java.util.AbstractMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,7 +36,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @TestWithResources
-public class WebHooksServiceTest extends ConversationBaseTest {
+public class WebHooksCallbackServiceTest extends ConversationBaseTest {
 
   com.sinch.sdk.domains.conversation.api.v1.WebHooksService serverService;
 
@@ -261,13 +260,6 @@ public class WebHooksServiceTest extends ConversationBaseTest {
 
   @BeforeEach
   public void setUp() {
-
-    Configuration configuration =
-        Configuration.builder()
-            .setProjectId("unused")
-            .setKeyId("unused")
-            .setKeySecret("unused")
-            .build();
-    serverService = new SinchClient(configuration).conversation().v1().webhooks();
+    serverService = new SinchClient().conversation().v1().webhooks();
   }
 }

--- a/client/src/test/java/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksProxyServiceTest.java
+++ b/client/src/test/java/com/sinch/sdk/domains/conversation/api/v1/adapters/WebHooksProxyServiceTest.java
@@ -1,0 +1,68 @@
+package com.sinch.sdk.domains.conversation.api.v1.adapters;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.adelean.inject.resources.junit.jupiter.TestWithResources;
+import com.sinch.sdk.core.exceptions.ApiException;
+import com.sinch.sdk.domains.conversation.api.v1.WebHooksService;
+import com.sinch.sdk.domains.conversation.models.v1.webhooks.Webhook;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+@TestWithResources
+public class WebHooksProxyServiceTest extends ConversationBaseTest {
+
+  WebHooksService service;
+
+  @Mock Runnable credentialValidation;
+  @Mock WebHooksApiService apiService;
+  @Mock WebHooksCallbackService callbackService;
+
+  @BeforeEach
+  public void initMocks() {
+    service = spy(new WebHooksProxyService(credentialValidation, apiService, callbackService));
+  }
+
+  @Test
+  void list() throws ApiException {
+
+    service.list("foo");
+
+    verify(credentialValidation, times(1)).run();
+  }
+
+  @Test
+  void get() throws ApiException {
+
+    service.get("foo");
+
+    verify(credentialValidation, times(1)).run();
+  }
+
+  @Test
+  void create() throws ApiException {
+
+    service.create(Webhook.builder().build());
+
+    verify(credentialValidation, times(1)).run();
+  }
+
+  @Test
+  void update() throws ApiException {
+
+    service.update("foo", Webhook.builder().build());
+
+    verify(credentialValidation, times(1)).run();
+  }
+
+  @Test
+  void delete() throws ApiException {
+
+    service.delete("foo");
+
+    verify(credentialValidation, times(1)).run();
+  }
+}

--- a/openapi-contracts/src/main/com/sinch/sdk/domains/conversation/api/v1/internal/WebhooksApi.java
+++ b/openapi-contracts/src/main/com/sinch/sdk/domains/conversation/api/v1/internal/WebhooksApi.java
@@ -37,10 +37,10 @@ import java.util.logging.Logger;
 public class WebhooksApi {
 
   private static final Logger LOGGER = Logger.getLogger(WebhooksApi.class.getName());
-  private HttpClient httpClient;
-  private ServerConfiguration serverConfiguration;
-  private Map<String, AuthManager> authManagersByOasSecuritySchemes;
-  private HttpMapper mapper;
+  private final HttpClient httpClient;
+  private final ServerConfiguration serverConfiguration;
+  private final Map<String, AuthManager> authManagersByOasSecuritySchemes;
+  private final HttpMapper mapper;
 
   public WebhooksApi(
       HttpClient httpClient,


### PR DESCRIPTION
Enable init and use a SinchClient instance without credential
It enable header authentication validation and event parsing not requiring credentials
