### PR TITLE
1.7 compatible version of the E2E tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,6 +57,7 @@ jobs:
           repository: sinch/sinch-sdk-mockserver
           token: ${{ secrets.MOCKSERVER_REPO_PAT_CI }}
           fetch-depth: 0
+          ref: 57b6c306152628b2d834241ec495e868ac696148
           path: sinch-sdk-mockserver
 
       - name: Install Docker Compose


### PR DESCRIPTION
Needed for the release script too, which is executing the E2E tests